### PR TITLE
[T] Allow deployment from develop branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ deploy:
   skip_cleanup: true
   local-dir: storybook-static
   acl: public_read
+  on:
+    branch: develop
 branches:
   only:
   - develop


### PR DESCRIPTION
Addition to #5 . 

By default, you are only allowed to deploy `master` branch.

See here: https://docs.travis-ci.com/user/deployment#examples-of-conditional-deployment