### PR TITLE
[B] Return the validation status when calling validate() in HdTextArea

### DIFF
--- a/src/components/form/HdTextarea.vue
+++ b/src/components/form/HdTextarea.vue
@@ -164,6 +164,7 @@ export default {
       } else {
         this.hideError();
       }
+      return !this.error;
     },
   },
 };


### PR DESCRIPTION
To comply with validation pattern we decided to go with.
This line is necessary to check the validity of the component from outside.