### PR TITLE
[B] Calculate and pass the offset position to HdNotificationsBar

### DIFF
--- a/src/components/notifications/HdNotificationsBar.vue
+++ b/src/components/notifications/HdNotificationsBar.vue
@@ -7,6 +7,7 @@
     }"
     :style="{
       'top': `${offsetTop}px`,
+      'right': `${offsetRight}px`,
       'left': `${offsetLeft}px`,
     }"
   >
@@ -58,6 +59,10 @@ export default {
       type: Number,
       default: 0,
     },
+    offsetRight: {
+      type: Number,
+      default: 0,
+    },
     offsetLeft: {
       type: Number,
       default: 0,
@@ -95,7 +100,6 @@ export default {
 .notifications-bar {
   display: flex;
   position: fixed;
-  right: 0;
   justify-content: center;
   opacity: 0;
   padding: $stack-m $inline-s;

--- a/src/stories/HdNotifications.stories.js
+++ b/src/stories/HdNotifications.stories.js
@@ -25,8 +25,9 @@ storiesOf('HdNotifications', module)
       },
     },
     template: `
-      <div style="max-width: 800px; margin: auto;">
+      <div>
         <HdNotifications
+          style="margin: -8px"
           :notifications="transformedNotifications"
           @heightChange="onHeightChange"
           @route="onRoute"
@@ -82,8 +83,9 @@ storiesOf('HdNotifications', module)
       },
     },
     template: `
-      <div style="max-width: 800px; margin: auto;">
+      <div>
         <HdNotifications
+          style="margin: -8px"
           :notifications="transformedNotifications"
           @heightChange="onHeightChange"
           @route="onRoute"


### PR DESCRIPTION
The HdNotificationsBar has position fixed, so it will always go to the top of the body, and this is not the desired behavior.
Now the bars (HdNotificationsBar) will take the same (offset) position as the wrapper (HdNotifications), so you can just style the latter, like in the story, and the bars will adapt to that.