### PR TITLE
[F] Show HdEditSwitch labels even on small screens

### DIFF
--- a/src/components/HdEditSwitch.vue
+++ b/src/components/HdEditSwitch.vue
@@ -170,14 +170,10 @@ $_red: #E00016;
         color: $_red;
       }
       &__label {
-        display: none;
         font-size: 18px;
         font-weight: 400;
         line-height: 26px;
         margin-left: $inline-xs;
-        @media (min-width: $break-tablet) {
-          display: block;
-        }
       }
     }
   }


### PR DESCRIPTION
https://homeday.atlassian.net/browse/CE-284

This is a visual change for a component that is so far only used in Mein Homeday, so I'll provide some visuals for context:

<details>
<summary>Before:</summary>

![localhost_6006__path=_story_hdeditswitch--concrete-example(iPhone 5_SE)](https://user-images.githubusercontent.com/2056251/55785450-c0647b80-5ab2-11e9-9f1a-9a8ef537d470.png)

![localhost_6006__path=_story_hdeditswitch--concrete-example(iPhone 5_SE) (1)](https://user-images.githubusercontent.com/2056251/55785456-c22e3f00-5ab2-11e9-8e8f-26b4efc15b78.png)
</details>

<details>
<summary>After:</summary>

![localhost_6006__path=_story_hdeditswitch--concrete-example(iPhone 5_SE) (3)](https://user-images.githubusercontent.com/2056251/55785478-cbb7a700-5ab2-11e9-9061-d13499e5c3e4.png)

![localhost_6006__path=_story_hdeditswitch--concrete-example(iPhone 5_SE) (2)](https://user-images.githubusercontent.com/2056251/55785479-cce8d400-5ab2-11e9-93eb-d325fa2e44a2.png)
</details>

Basically, initially, the idea was for icons to be placed next to items that are editable. We have since gone with the approach of displaying them on top (since it would not work otherwise on smaller screens). Now that we have a full row free for the labels, it makes no sense to hide their text on smaller screens.