### PR TITLE
[T] Placeholder color to 50% regent gray

### DIFF
--- a/src/styles/inputs.scss
+++ b/src/styles/inputs.scss
@@ -331,6 +331,11 @@ $inputFilledBackground: #e8eaee;
     #{$f}--disabled & {
       color: rgba($regent-gray, 0.8);
     }
+
+    &::placeholder {
+      color: $regent-gray;
+      opacity: 0.5;
+    }
   }
 
   &__tooltip {


### PR DESCRIPTION
https://homeday.atlassian.net/browse/CA-866

It is a request from our designers as before we were using browser default.

Before:
![Placeholder before](https://user-images.githubusercontent.com/1734873/57468458-c782d300-7284-11e9-99e6-c3b9c9a41608.png)

After:
![Placeholder after](https://user-images.githubusercontent.com/1734873/57468494-d5385880-7284-11e9-9679-5e0e8e63b781.png)

Reference: https://github.com/homeday-de/styleguide/pull/109