### PR TITLE
[B] Disable pointer-events for <textarea> :before

### DIFF
--- a/src/styles/inputs.scss
+++ b/src/styles/inputs.scss
@@ -70,6 +70,7 @@ $inputFilledBackground: #e8eaee;
       background: $inputBackground;
       display: block;
       z-index: 1;
+      pointer-events: none;
     }
 
     &#{$f}--filled:not(#{$f}--active):not(#{$f}--invalid):before {


### PR DESCRIPTION
It wasn't possible to click on the label/top of the text area and input something. You had to click a bit down to avoid clicking on the :before pseudo-element.

Now once you click on the label/top it focus on the <textarea>