### PR TITLE
[F] Label positioning for textarea elements

### DIFF
--- a/src/styles/inputs.scss
+++ b/src/styles/inputs.scss
@@ -4,6 +4,7 @@ $innerIconDimension: 18px;
 $inputLeftPadding: $inline-s;
 $inputBackground: #f4f5f6;
 $inputFilledBackground: #e8eaee;
+$inputPaddingTop: $labelHeight + $stack-s;
 
 .field {
   $f: &;
@@ -148,11 +149,12 @@ $inputFilledBackground: #e8eaee;
     }
 
     #{$f}--textarea & {
-      top: $stack-s;
+      top: $inputPaddingTop;
+    }
 
-      #{$f}--filled &, #{$f}--active & {
-        bottom: initial;
-      }
+    #{$f}--textarea#{$f}--filled &, #{$f}--textarea#{$f}--active &{
+      top: $stack-s;
+      bottom: initial;
     }
 
     #{$f}--required & {
@@ -281,7 +283,7 @@ $inputFilledBackground: #e8eaee;
     outline: none;
     border-radius: $default-border-radius;
 
-    padding-top: $labelHeight + $stack-s;
+    padding-top: $inputPaddingTop;
     padding-left: $inputLeftPadding;
     padding-right: $inline-s;
     padding-bottom: $stack-s;


### PR DESCRIPTION
The new design is more coherent with our general material design. I had to make it on kirby v2, so I reported also there.

What changes is the positioning of the label in the --active state.