### PR TITLE
[T] Explicitly list GitHub users as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @homeday-de/frontend-engineering
+* @viniciuskneves @SinisaG @OlegIvaniv @drapisarda @ilyasmez @OriginalEXE


### PR DESCRIPTION
Looks like the CODEOWNERS feature does not work with private teams, so we instead list the team members explicitly.