### PR TITLE
[B] Reference event emitter inside Homeday Blocks

### DIFF
--- a/src/services/on-resize.js
+++ b/src/services/on-resize.js
@@ -1,4 +1,4 @@
-import EventEmitter from '@/services/event-emitter';
+import EventEmitter from 'hd-blocks/services/event-emitter';
 import throttle from 'lodash/throttle';
 import debounce from 'lodash/debounce';
 


### PR DESCRIPTION
Right now it references the one found in Mein Homeday (as we use `@` as an alias there)