### PR TITLE
[B] Show the carousel only if we have more than one image

### DIFF
--- a/src/components/gallery/HdGallery.vue
+++ b/src/components/gallery/HdGallery.vue
@@ -255,7 +255,7 @@ export default {
   
   &__carousel {
     #{$_root}.hasSingleItem & {
-      @include for('tablet') {
+      @media (min-width: $break-tablet) {
         display: none;
       }
     }


### PR DESCRIPTION
Just a small fix, as it doesn't make sense to show the carousel if we have just one item.

FYI @drapisarda 

(I went with `display: none`, instead of not showing the carousel at all, because on mobile we show just the carousel :/ )