### PR TITLE
[B] Check if ref is defined before proceeding with initializing

### DIFF
--- a/src/components/form/HdGoogleAutocomplete.vue
+++ b/src/components/form/HdGoogleAutocomplete.vue
@@ -134,6 +134,10 @@ export default {
         types: ['(regions)'],
       };
 
+      if (!this.$refs.input) {
+        return;
+      }
+
       this.autocompleteInstance = new window.google.maps.places.Autocomplete(
         this.$refs.input,
         autocompleteOptions,


### PR DESCRIPTION
If the component is unmounted before it has the time to fetch the Google API, the ref will not be defined and so an error is thrown.

This change makes sure we check for the existence of the ref before proceeding.