### PR TITLE
[F] Better padding for gallery overlay on short devices

### DIFF
--- a/src/components/gallery/HdGalleryOverlay.vue
+++ b/src/components/gallery/HdGalleryOverlay.vue
@@ -81,7 +81,7 @@ export default {
   background-color: rgba(white, .9);
   animation: fadeIn .5s;
 
-  @media (min-width: $break-tablet) {
+  @media (min-width: $break-tablet) and (min-height: 800px) {
     padding: $inset-xl;
   }
 


### PR DESCRIPTION
This reduces the modal padding for short screens, so all of the gallery is displayed