### PR TITLE
[T] Update demo branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ deploy:
   skip_cleanup: true
   local-dir: storybook-static
   acl: public_read
-  upload-dir: develop
+  upload-dir: master
   on:
-    branch: develop
+    branch: master
 branches:
   only:
   - develop


### PR DESCRIPTION
Hey team,

this is now publicly published library, so I though to change our deploy to `master` branch. The reason for this is, that if we keep deploying on `develop`, our library actual released state (`master`) and our storybook demo (`develop`) will get temporary out of sync. That is not ideal. So the docs should always show ready to use version and be updated with releases. 

What do you think? Do we need more envs? We can also opt in again for local deploy, so if you need to showcase the changes before going live, you can deploy on demand to s3. 

With this PR I'd like to open discussion on that.