### PR TITLE
[F] Emit 'blur' and 'focus' from HdInput

### DIFF
--- a/src/components/form/HdInput.vue
+++ b/src/components/form/HdInput.vue
@@ -152,10 +152,12 @@ export default {
     },
     handleFocus() {
       this.isActive = true;
+      this.$emit('focus');
     },
     handleBlur() {
       this.isActive = false;
       this.validate();
+      this.$emit('blur');
     },
     handleInput(e) {
       let newValue = e.target.value;


### PR DESCRIPTION
We weren't emitting those events and as the `input` is wrapped into a `div` it wouldn't just work adding the listeners in the parent.