### PR TITLE
[B] Transpile Vue-Zoomer to work on IE11

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -22,4 +22,5 @@ module.exports = {
       },
     },
   },
+  transpileDependencies: ['vue-zoomer'],
 };


### PR DESCRIPTION
Currently our storybook doesn't work on IE11.
As we are directly consuming the raw components from `vue-zoomer` (the same way we do for Blocks' components in other projects), this dependency needs to be transpiled as it contains ES6 code.