### PR TITLE
[B] Add default labels to dependabot PRs

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -5,3 +5,5 @@ update_configs:
     directory: "/"
     update_schedule: "weekly"
     target_branch: "develop"
+    default_labels:
+      - "bot"


### PR DESCRIPTION
We forgot to add this one to the configuration file (we had it before in the UI config).
It's used by Pull Reminders to ignore bot PRs.