### PR TITLE
[T] Remove coverall token

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,0 @@
-service_name: travis-pro
-repo_token: 9w8H3LVdjGhOpjhW461fxEMighMzzJX1a


### PR DESCRIPTION
As repo is now public, we don't need a token anymore, or a pro service. :clap: 
