### PR TITLE
[F] HDAlert message in a div instead of in a p

### DIFF
--- a/src/components/HdAlert.vue
+++ b/src/components/HdAlert.vue
@@ -11,11 +11,11 @@
       :src="iconSrc"
       class="alert__icon"
     >
-    <p
+    <div
       class="alert__message"
     >
       <slot />
-    </p>
+    </div>
   </div>
 </template>
 

--- a/tests/unit/components/__snapshots__/HdAlert.spec.js.snap
+++ b/tests/unit/components/__snapshots__/HdAlert.spec.js.snap
@@ -2,6 +2,6 @@
 
 exports[`HdAlert renders component 1`] = `
 <div class="alert alert--info"><img src="" class="alert__icon">
-  <p class="alert__message"><b>Default slot</b></p>
+  <div class="alert__message"><b>Default slot</b></div>
 </div>
 `;


### PR DESCRIPTION
Since we are displaying the slot, we should have it inside of a div instead of a p. So if we have a paragraph in the slot, we will not nest paragraphs.