### PR TITLE
[B] Ignore LastPass extension from auto filling inputs

### DIFF
--- a/src/components/form/HdInput.vue
+++ b/src/components/form/HdInput.vue
@@ -21,6 +21,7 @@
       :disabled="disabled"
       class="field__input"
       ref="input"
+      data-lpignore="true"
       @input="handleInput"
       @focus="handleFocus"
       @blur="handleBlur"

--- a/tests/unit/components/form/HdInput.spec.js
+++ b/tests/unit/components/form/HdInput.spec.js
@@ -248,4 +248,11 @@ describe('HdInput', () => {
     expect(wrapper.classes()).toContain(FIELD_CLASSES.HAS_ICON);
     expect(wrapper.find(ICON_SELECTOR).exists()).toBe(true);
   });
+
+  test('ignores LastPass auto fill', () => {
+    expect(wrapper
+      .find('input')
+      .attributes()['data-lpignore'])
+      .toBe('true');
+  });
 });

--- a/tests/unit/components/form/__snapshots__/HdInput.spec.js.snap
+++ b/tests/unit/components/form/__snapshots__/HdInput.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`HdInput is rendered as expected 1`] = `
 <div class="field field--input">
-  <!----> <input autocomplete="on" type="text" id="test name" name="test name" placeholder="" class="field__input"> <label for="test name" class="field__label">
+  <!----> <input autocomplete="on" type="text" id="test name" name="test name" placeholder="" data-lpignore="true" class="field__input"> <label for="test name" class="field__label">
     test label
   </label>
   <!---->

--- a/tests/unit/components/tooltip/__snapshots__/HdTooltipped.spec.js.snap
+++ b/tests/unit/components/tooltip/__snapshots__/HdTooltipped.spec.js.snap
@@ -4,7 +4,7 @@ exports[`HDTooltipped the component is rendered 1`] = `<span></span>`;
 
 exports[`HDTooltipped the component is rendered 2`] = `
 <div class="field field--input">
-  <!----> <input autocomplete="on" type="text" id="testInput" name="testInput" placeholder="" class="field__input"> <label for="testInput" class="field__label">
+  <!----> <input autocomplete="on" type="text" id="testInput" name="testInput" placeholder="" data-lpignore="true" class="field__input"> <label for="testInput" class="field__label">
     dolor sit ammet
   </label>
   <!---->


### PR DESCRIPTION
LastPass breaks UX, especially with our collapsible forms.
Ignoring it can be done easily by adding this attribute : **data-lpignore="true"**
![image](https://user-images.githubusercontent.com/7534298/70899660-5c0d9a80-1ff7-11ea-8863-4c67b9f94623.png)
