### PR TITLE
[T] import mixins.scss explicitly in each component

### DIFF
--- a/src/components/HdAlert.vue
+++ b/src/components/HdAlert.vue
@@ -69,6 +69,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import 'hd-blocks/styles/mixins.scss';
+
 .alert {
   display: flex;
   padding: $inset-s;

--- a/src/components/HdBadge.vue
+++ b/src/components/HdBadge.vue
@@ -107,6 +107,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import 'hd-blocks/styles/mixins.scss';
+
 .badge{
     display: flex;
     justify-content: flex-start;

--- a/src/components/HdCalendar.vue
+++ b/src/components/HdCalendar.vue
@@ -155,6 +155,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import 'hd-blocks/styles/mixins.scss';
+
 // Transitions
 .calendar {
   &-left {

--- a/src/components/HdEditSwitch.vue
+++ b/src/components/HdEditSwitch.vue
@@ -145,6 +145,8 @@ export default {
 </script>
 
 <style lang="scss">
+@import 'hd-blocks/styles/mixins.scss';
+
 $_red: #E00016;
 
 .edit-switch {

--- a/src/components/HdPager.vue
+++ b/src/components/HdPager.vue
@@ -248,7 +248,9 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import 'hd-blocks/styles/mixins.scss';
 @import 'hd-blocks/styles/inputs.scss';
+
 @keyframes pager-ripple {
   0% {
     opacity: 1;

--- a/src/components/HdSuggestionItem.vue
+++ b/src/components/HdSuggestionItem.vue
@@ -64,6 +64,8 @@ export default {
 </script>
 
 <style lang="scss">
+@import 'hd-blocks/styles/mixins.scss';
+
 .suggestionItem {
   $sI: &;
   @include font('text-xsmall');

--- a/src/components/HdTable.vue
+++ b/src/components/HdTable.vue
@@ -51,6 +51,8 @@ export default {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped lang="scss">
+@import 'hd-blocks/styles/mixins.scss';
+
 .hd-table {
   margin-top: $stack-s;
   @include font('text-xsmall');

--- a/src/components/HdTagsList.vue
+++ b/src/components/HdTagsList.vue
@@ -23,6 +23,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import 'hd-blocks/styles/mixins.scss';
+
 .tags-list {
   display: flex;
   flex-wrap: wrap;

--- a/src/components/HdTimeslots.vue
+++ b/src/components/HdTimeslots.vue
@@ -106,6 +106,8 @@ export default {
 </script>
 
 <style lang="scss">
+@import 'hd-blocks/styles/mixins.scss';
+
 .timeslots-transition {
   &-left, &-right {
     &-leave-active, &-enter-active {

--- a/src/components/HdToast.vue
+++ b/src/components/HdToast.vue
@@ -69,6 +69,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import 'hd-blocks/styles/mixins.scss';
 $toastWidth: 288px;
 
 .toast {

--- a/src/components/buttons/HdArrowButton.vue
+++ b/src/components/buttons/HdArrowButton.vue
@@ -30,6 +30,8 @@ export default {
 </script>
 
 <style lang="scss">
+@import 'hd-blocks/styles/mixins.scss';
+
 .arrowButton {
   border: none;
   width: 16px;

--- a/src/components/buttons/HdLoaderButton.vue
+++ b/src/components/buttons/HdLoaderButton.vue
@@ -208,6 +208,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import 'hd-blocks/styles/mixins.scss';
 
 .loaderButton {
   $lB: &;

--- a/src/components/buttons/HdRadioButton.vue
+++ b/src/components/buttons/HdRadioButton.vue
@@ -75,6 +75,8 @@ export default {
 </script>
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped lang="scss">
+@import 'hd-blocks/styles/mixins.scss';
+
 $iconWidth: 48px;
 .radioButton {
   $rB: &;

--- a/src/components/form/HdAutocomplete.vue
+++ b/src/components/form/HdAutocomplete.vue
@@ -163,6 +163,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import 'hd-blocks/styles/mixins.scss';
 
 .autocomplete {
   &__suggestions {

--- a/src/components/form/HdCheckbox.vue
+++ b/src/components/form/HdCheckbox.vue
@@ -137,6 +137,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import 'hd-blocks/styles/mixins.scss';
 
 .checkbox {
   $c: &;

--- a/src/components/form/HdDynamicForm.vue
+++ b/src/components/form/HdDynamicForm.vue
@@ -139,6 +139,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import 'hd-blocks/styles/mixins.scss';
 
 .dynamicForm {
   &__line {

--- a/src/components/form/HdGoogleAutocomplete.vue
+++ b/src/components/form/HdGoogleAutocomplete.vue
@@ -258,6 +258,7 @@ export default {
 </script>
 
 <style scoped lang="scss">
+@import 'hd-blocks/styles/mixins.scss';
 @import 'hd-blocks/styles/inputs.scss';
 .field {
   &__label {

--- a/src/components/form/HdInput.vue
+++ b/src/components/form/HdInput.vue
@@ -214,6 +214,7 @@ export default {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped lang="scss">
+@import 'hd-blocks/styles/mixins.scss';
 @import 'hd-blocks/styles/inputs.scss';
 
 .field {

--- a/src/components/form/HdInputPassword.vue
+++ b/src/components/form/HdInputPassword.vue
@@ -56,6 +56,7 @@ export default {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped lang="scss">
+@import 'hd-blocks/styles/mixins.scss';
 
 .passwordInput {
   position: relative;

--- a/src/components/form/HdPasswordConfirm.vue
+++ b/src/components/form/HdPasswordConfirm.vue
@@ -165,6 +165,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import 'hd-blocks/styles/mixins.scss';
+
 .confirmPassword {
   width: 100%;
   position: relative;

--- a/src/components/form/HdRadio.vue
+++ b/src/components/form/HdRadio.vue
@@ -218,6 +218,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import 'hd-blocks/styles/mixins.scss';
 @import 'hd-blocks/styles/inputs.scss';
 
 .radio {

--- a/src/components/form/HdSelect.vue
+++ b/src/components/form/HdSelect.vue
@@ -161,6 +161,8 @@ export default {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped lang="scss">
+@import 'hd-blocks/styles/mixins.scss';
+
 .field {
   &__error {
     width: 100%;

--- a/src/components/form/HdSplitInput.vue
+++ b/src/components/form/HdSplitInput.vue
@@ -190,7 +190,9 @@ export default {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped lang="scss">
+@import 'hd-blocks/styles/mixins.scss';
 @import 'hd-blocks/styles/inputs.scss';
+
 .field {
   $f: &;
   &__double-input {

--- a/src/components/form/HdTagsSelector.vue
+++ b/src/components/form/HdTagsSelector.vue
@@ -165,6 +165,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import 'hd-blocks/styles/mixins.scss';
+
 .tags-selector {
   position: relative;
   margin-bottom: $stack-m;

--- a/src/components/form/HdTextarea.vue
+++ b/src/components/form/HdTextarea.vue
@@ -185,6 +185,7 @@ export default {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped lang="scss">
+@import 'hd-blocks/styles/mixins.scss';
 @import 'hd-blocks/styles/inputs.scss';
 
 .field {

--- a/src/components/gallery/HdGallery.vue
+++ b/src/components/gallery/HdGallery.vue
@@ -165,6 +165,8 @@ export default {
 </script>
 
 <style lang="scss">
+@import 'hd-blocks/styles/mixins.scss';
+
 .gallery {
   $_root: &;
   position: relative;

--- a/src/components/gallery/HdGalleryOverlay.vue
+++ b/src/components/gallery/HdGalleryOverlay.vue
@@ -80,6 +80,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import 'hd-blocks/styles/mixins.scss';
+
 .gallery-overlay {
   position: fixed;
   top: 0;

--- a/src/components/gallery/HdGalleryTiles.vue
+++ b/src/components/gallery/HdGalleryTiles.vue
@@ -60,6 +60,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import 'hd-blocks/styles/mixins.scss';
+
 .gallery-tiles {
   position: relative;
   height: 100%;

--- a/src/components/gallery/HdZoomerGallery.vue
+++ b/src/components/gallery/HdZoomerGallery.vue
@@ -63,6 +63,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import 'hd-blocks/styles/mixins.scss';
+
 .zoomer-gallery {
   $_root: &;
 

--- a/src/components/tooltip/HdTooltip.vue
+++ b/src/components/tooltip/HdTooltip.vue
@@ -13,6 +13,7 @@ export default {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped lang="scss">
+@import 'hd-blocks/styles/mixins.scss';
 
 .hd-tooltip {
   position: absolute;

--- a/src/stories/Welcome.vue
+++ b/src/stories/Welcome.vue
@@ -50,6 +50,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import 'hd-blocks/styles/mixins.scss';
 @import "~vue-code-highlight/themes/prism.css";
 
 .welcome {

--- a/vue.config.js
+++ b/vue.config.js
@@ -13,14 +13,15 @@ module.exports = {
         fix: true,
       });
   },
-  css: {
-    loaderOptions: {
-      sass: {
-        prependData: `
-          @import "hd-blocks/styles/mixins.scss";
-        `,
-      },
-    },
-  },
   transpileDependencies: ['vue-zoomer'],
+  // uncomment to import mixins.scss implicitly in all components
+  // css: {
+  //   loaderOptions: {
+  //     sass: {
+  //       prependData: `
+  //         @import "hd-blocks/styles/mixins.scss";
+  //       `,
+  //     },
+  //   },
+  // },
 };

--- a/vue.config.js
+++ b/vue.config.js
@@ -14,14 +14,4 @@ module.exports = {
       });
   },
   transpileDependencies: ['vue-zoomer'],
-  // uncomment to import mixins.scss implicitly in all components
-  // css: {
-  //   loaderOptions: {
-  //     sass: {
-  //       prependData: `
-  //         @import "hd-blocks/styles/mixins.scss";
-  //       `,
-  //     },
-  //   },
-  // },
 };


### PR DESCRIPTION
Some components don't explicitly reference mixins. This is not visible, as we deal with it in our projects like that: https://github.com/homeday-de/customer-app/blob/develop/vue.config.js#L56-L61 

However, this is undocumented magic.   And this should not be necessary. 

Make components more robust, by importing mixins explicitly in each component. They don't cost anything, as they don't output CSS.