### PR TITLE
[F] Support custom validators for google autocomplete input

### DIFF
--- a/src/components/form/HdGoogleAutocomplete.vue
+++ b/src/components/form/HdGoogleAutocomplete.vue
@@ -92,6 +92,9 @@ export default {
     customRules: {
       type: Array,
       default: () => [],
+      validator: rulesProvided => rulesProvided.every(
+        ({ validate, errorMessage }) => typeof validate === 'function' && typeof errorMessage === 'string',
+      ),
     },
   },
   data() {

--- a/src/components/form/HdGoogleAutocomplete.vue
+++ b/src/components/form/HdGoogleAutocomplete.vue
@@ -255,16 +255,20 @@ export default {
     validate() {
       if (this.required && this.isEmpty) {
         this.showError(this.t.FORM.VALIDATION.REQUIRED);
+      } else if (this.customRules.length && !this.isEmpty) {
+        this.validateCustomRules();
       } else {
-        const firstFailingRule = this.customRules.find(({ validate }) => !validate(this.value));
-
-        if (firstFailingRule) {
-          this.showError(firstFailingRule.errorMessage);
-        } else {
-          this.hideError();
-        }
+        this.hideError();
       }
       return !this.error;
+    },
+    validateCustomRules() {
+      const firstFailingRule = this.customRules.find(({ validate }) => !validate(this.value));
+      if (firstFailingRule) {
+        this.showError(firstFailingRule.errorMessage);
+      } else {
+        this.hideError();
+      }
     },
   },
 };

--- a/src/components/form/HdGoogleAutocomplete.vue
+++ b/src/components/form/HdGoogleAutocomplete.vue
@@ -89,7 +89,7 @@ export default {
       type: Boolean,
       default: false,
     },
-    customValidators: {
+    customRules: {
       type: Array,
       default: () => [],
     },
@@ -253,12 +253,10 @@ export default {
       if (this.required && this.isEmpty) {
         this.showError(this.t.FORM.VALIDATION.REQUIRED);
       } else {
-        const [firstFailingValidation] = this.customValidators
-          .map(validator => validator(this.value))
-          .filter(validationResult => !validationResult.isValid);
+        const firstFailingRule = this.customRules.find(({ validate }) => !validate(this.value));
 
-        if (firstFailingValidation) {
-          this.showError(firstFailingValidation.errorMessage);
+        if (firstFailingRule) {
+          this.showError(firstFailingRule.errorMessage);
         } else {
           this.hideError();
         }

--- a/src/components/form/HdGoogleAutocomplete.vue
+++ b/src/components/form/HdGoogleAutocomplete.vue
@@ -89,6 +89,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    customValidators: {
+      type: Array,
+      default: () => [],
+    },
   },
   data() {
     return {
@@ -249,7 +253,15 @@ export default {
       if (this.required && this.isEmpty) {
         this.showError(this.t.FORM.VALIDATION.REQUIRED);
       } else {
-        this.hideError();
+        const [firstFailingValidation] = this.customValidators
+          .map(validator => validator(this.value))
+          .filter(validationResult => !validationResult.isValid);
+
+        if (firstFailingValidation) {
+          this.showError(firstFailingValidation.errorMessage);
+        } else {
+          this.hideError();
+        }
       }
       return !this.error;
     },

--- a/tests/unit/components/form/HdGoogleAutocomplete.spec.js
+++ b/tests/unit/components/form/HdGoogleAutocomplete.spec.js
@@ -69,17 +69,17 @@ describe('HdGoogleAutocomplete', () => {
   });
 
 
-  describe('Supports custom validators with error message', () => {
+  describe('Supports custom rules with error message', () => {
     const atLeastTenCharsErrorMessage = 'should be at least ten characters long';
-    const atLeastTenChars = value => ({ isValid: value.length >= 10, errorMessage: atLeastTenCharsErrorMessage });
+    const atLeastTenChars = { validate: value => value.length >= 10, errorMessage: atLeastTenCharsErrorMessage };
 
     const startsWithSpaceErrorMessage = 'should start with empty space';
-    const startsWithSpace = value => ({ isValid: value[0] === ' ', errorMessage: startsWithSpaceErrorMessage });
+    const startsWithSpace = { validate: value => value[0] === ' ', errorMessage: startsWithSpaceErrorMessage };
 
     test('Simple case', () => {
       // invalid
       wrapper.setProps({
-        customValidators: [atLeastTenChars],
+        customRules: [atLeastTenChars],
         value: 'too short',
       });
 
@@ -90,7 +90,7 @@ describe('HdGoogleAutocomplete', () => {
 
       // valid
       wrapper.setProps({
-        customValidators: [atLeastTenChars],
+        customRules: [atLeastTenChars],
         value: 'this one is long enough',
       });
 
@@ -103,7 +103,7 @@ describe('HdGoogleAutocomplete', () => {
     test('Multiple custom validators: first one has highest importance', () => {
       // both invalid
       wrapper.setProps({
-        customValidators: [startsWithSpace, atLeastTenChars],
+        customRules: [startsWithSpace, atLeastTenChars],
         value: 'short',
       });
 
@@ -114,7 +114,7 @@ describe('HdGoogleAutocomplete', () => {
 
       // first one valid, second one invalid
       wrapper.setProps({
-        customValidators: [startsWithSpace, atLeastTenChars],
+        customRules: [startsWithSpace, atLeastTenChars],
         value: ' short',
       });
 

--- a/tests/unit/components/form/HdGoogleAutocomplete.spec.js
+++ b/tests/unit/components/form/HdGoogleAutocomplete.spec.js
@@ -67,4 +67,61 @@ describe('HdGoogleAutocomplete', () => {
 
     expect(wrapper.find('input').attributes().disabled).toBe('disabled');
   });
+
+
+  describe('Supports custom validators with error message', () => {
+    const atLeastTenCharsErrorMessage = 'should be at least ten characters long';
+    const atLeastTenChars = value => ({ isValid: value.length >= 10, errorMessage: atLeastTenCharsErrorMessage });
+
+    const startsWithSpaceErrorMessage = 'should start with empty space';
+    const startsWithSpace = value => ({ isValid: value[0] === ' ', errorMessage: startsWithSpaceErrorMessage });
+
+    test('Simple case', () => {
+      // invalid
+      wrapper.setProps({
+        customValidators: [atLeastTenChars],
+        value: 'too short',
+      });
+
+      wrapper.vm.validate();
+
+      expect(wrapper.vm.isValid).toBe(false);
+      expect(wrapper.vm.error).toBe(atLeastTenCharsErrorMessage);
+
+      // valid
+      wrapper.setProps({
+        customValidators: [atLeastTenChars],
+        value: 'this one is long enough',
+      });
+
+      wrapper.vm.validate();
+
+      expect(wrapper.vm.isValid).toBe(true);
+      expect(wrapper.vm.error).toBeFalsy();
+    });
+
+    test('Multiple custom validators: first one has highest importance', () => {
+      // both invalid
+      wrapper.setProps({
+        customValidators: [startsWithSpace, atLeastTenChars],
+        value: 'short',
+      });
+
+      wrapper.vm.validate();
+
+      expect(wrapper.vm.isValid).toBe(false);
+      expect(wrapper.vm.error).toBe(startsWithSpaceErrorMessage);
+
+      // first one valid, second one invalid
+      wrapper.setProps({
+        customValidators: [startsWithSpace, atLeastTenChars],
+        value: ' short',
+      });
+
+      wrapper.vm.validate();
+
+      expect(wrapper.vm.isValid).toBe(false);
+      expect(wrapper.vm.error).toBe(atLeastTenCharsErrorMessage);
+    });
+  });
 });


### PR DESCRIPTION
- I noticed this use case while implementing validation for location searches. I had to programmatically set errors to the input reference. 

- The idea is to allow to declaratively configure validations for an input like so:
```
  props: {
        ...
        customValidators: [
          (value) => ({ isValid: value.length >= 10, errorMessage: 'should be at least ten characters long' })
       ],
      },
```

- Please let me know your thoughts. If you think it's a good idea, I'm happy to add async validation support as well as support the generic  `HDInput`