### PR TITLE
[B] Update package version in package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homeday-blocks",
-  "version": "5.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
I do always recommend to use [`npm version`](https://docs.npmjs.com/cli/version.html) to release a new version instead of manually updating the package version.