### PR TITLE
[T] Move services to root

### DIFF
--- a/services/README.md
+++ b/services/README.md
@@ -1,0 +1,221 @@
+# Services
+Homeday Blocks contains a number of services that we found ourself needing across projects. Some of them are used by Homeday Blocks components, others 
+are here to be consumed in projects directly.
+
+Index:
+- [Breakpoints service](#breakpoints) - Used for setting (and getting) the global project breakpoints.
+- [Date service](#date) - Used as helpers to work with dates and date intervals.
+- [Utils service](#utils) - Group of helpers that have generic usage.
+
+## Breakpoints
+Exposes methods for setting up viewport breakpoints of the project. The breakpoints set in this way are later used by the `HdResponsive` component.
+
+### Usage
+In your project entry file, import the service and define breakpoints that make sense for your project:
+
+```js
+import { setBreakpoints } from 'homeday-blocks/src/services/breakpoints';
+
+const breakpoints = {
+  s: '(max-width:599px)',
+  m: '(min-width:600px)',
+  l: '(min-width:900px)',
+  xl: '(min-width:1200px)',
+};
+setBreakpoints(breakpoints);
+```
+
+You can now import a helper component and render contents based on your breakpoints matching or not:
+
+```vue
+<script>
+import { HdResponsive } from 'homeday-blocks';
+</script>
+
+<template>
+<HdResponsive #default="{ matches, indeterminate }">
+  <div v-if="indeterminate">Matching could not be reliably determined (server side rendering, unit tests environment)</div>
+  <div v-else-if="matches.xl">xl breakpoint matched</div>
+  <div v-else-if="matches.m">m breakpoint matched</div>
+</HdResponsive>
+</template>
+```
+
+As seen in the example above, `HdResponsive` component exposes two arguments:
+- `matches`: Object with the keys matching your breakpoints object and boolean values (`true`: matches, `false`: does not match the current viewport)
+```
+> console.log(typeof matches, matches);
+object {s: false, m: false, l: true, xl: false}
+```
+- `indeterminate`: Boolean set to `true` if a viewport size could not be measured (SSR, unit tests). Can be used to provide fallback content for rendering on the server. You can optionally ignore this if you don't use server side rendering.
+```
+> console.log(typeof indeterminate, indeterminate);
+boolean true
+```
+
+It is worth noting that HdResponsive component takes a `breakpoints` prop as well in case you want to override global ones for a specific instance:
+```vue
+<template>
+<HdResponsive
+  #default="{ matches, indeterminate }"
+  :breakpoints="{
+    l: '(min-width:999px)',
+    gigantic: '(min-width: 2560px)',
+  }"
+>
+  <div v-if="matches.l">l breakpoint (overridden) matched</div>
+  <div v-else-if="matches.gigantic">gigantic breakpoint matched (specific to this HdResponsive instance)</div>
+  <div v-else-if="matches.m">m breakpoint matched (global breakpoints still available since objects are merged)</div>
+</HdResponsive>
+</template>
+```
+
+## Date
+
+#### resetDateTime
+
+Returns date with hour, minutes, seconds and miliseconds set to `0`.
+
+`param {Date} date - arbitrary date`
+
+Example:
+
+```javascript
+const date = new Date(2018, 1, 15, 16, 30, 30, 30); // 15.2.2018 at 16:30:30:30
+
+const date2 = resetDateTime(date); // 15.2.2018 at 00:00:00:00
+```
+
+#### getNDaysFromDate
+
+Returns new date that is N days away from inputted date, with hour, minutes, seconds and miliseconds set to `0`.
+
+`param {Date} initialDate: Arbitrary date`
+
+`param {Number} amountOfDays: Offset in days`
+
+```javascript
+const initialDate = new Date(2018, 1, 15, 16, 30, 30, 30); // 15.2.2018 at 16:30:30:30
+const amountOfDays = 1;
+
+const date2 = getNDaysFromDate(initialDate, amountOfDays); // 16.2.2018 at 00:00:00:00
+```
+
+#### convertMsToDays
+
+Returns number of days from miliseconds.
+
+`param {Number} ms: Miliseconds`
+
+```javascript
+const ms = 5 * 24 * 60 * 60 * 1000; // 432000000
+
+const days = convertMsToDays(ms); // 5 days
+```
+
+#### getDaysDateRange
+
+Returns array of date range between 2 dates, including start date and **excluding** end date
+
+`param {Date} startDate: Start of time interval`
+
+`param {Date} endDate: End of time interval`
+
+```javascript
+const startDate = new Date(2018, 0, 1);
+const endDate = new Date(2018, 0, 3);
+
+const timeInterval = getDaysDateRange(startDate, endDate);
+// [ 2018-01-01T00:00:00.000Z, 2018-01-02T00:00:00.000Z ]
+```
+
+#### getIntlDateString
+
+Returns array of **unique** day names in arbitrary(passed) date list
+
+`param {String} locale: Valid locale`
+
+`param {Array} datesArray : List of dates to be checked for day name`
+
+`param {Object} localStringArgs - Locale options` - [Full List](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString#Parameters)
+
+
+```javascript
+const locale = 'en-US';
+const datesArray = [new Date(2018, 0, 1)];
+const localStringArgs = { weekday: 'long' };
+
+const daysInIntervalLong = getIntlDateString(locale, datesArray, localStringArgs);
+// [ 'Monday' ]
+```
+
+#### generateDateCycles
+
+Returns an array of dates in N (`cycleLengthWeeks`) weeks, with M cycles (`amountOfCycles`) from selected offset(in days) from today (`startDateOffset`)
+
+`param {Number} cycleLengthWeeks: Total number of weeks in the cycle`
+
+`param {Number} amountOfCycles: Number of cycles to generate`
+
+`param {Number} startDateOffset: Offset in days e.g.: 0 = today, -1 = yesterday ,...`
+
+```javascript
+const cycleLengthWeeks = 2;
+const amountOfCycles = 2;
+const startDateOffset = 0;
+
+const dateCycles = generateDateCycles(cycleLengthWeeks, amountOfCycles, startDateOffset);
+/*
+  [
+    2020-01-28T00:00:00.000Z,
+    2020-01-29T00:00:00.000Z,
+    2020-01-30T00:00:00.000Z,
+    2020-01-31T00:00:00.000Z,
+    2020-02-01T00:00:00.000Z,
+    2020-02-02T00:00:00.000Z,
+    2020-02-03T00:00:00.000Z,
+    2020-02-04T00:00:00.000Z,
+    2020-02-05T00:00:00.000Z,
+    2020-02-06T00:00:00.000Z,
+    2020-02-07T00:00:00.000Z,
+    2020-02-08T00:00:00.000Z,
+    2020-02-09T00:00:00.000Z,
+    2020-02-10T00:00:00.000Z,
+    2020-02-11T00:00:00.000Z,
+    2020-02-12T00:00:00.000Z,
+    2020-02-13T00:00:00.000Z,
+    2020-02-14T00:00:00.000Z,
+    2020-02-15T00:00:00.000Z,
+    2020-02-16T00:00:00.000Z,
+    2020-02-17T00:00:00.000Z,
+    2020-02-18T00:00:00.000Z,
+    2020-02-19T00:00:00.000Z,
+    2020-02-20T00:00:00.000Z,
+    2020-02-21T00:00:00.000Z,
+    2020-02-22T00:00:00.000Z,
+    2020-02-23T00:00:00.000Z,
+    2020-02-24T00:00:00.000Z
+  ]
+*/
+```
+
+## Utils
+
+#### generateUniqueNumbers
+
+Returns array of N(`count`) indexes on `min` to `max` closed(including `min` and `max`) interval. In case that requested `amount` is larger then different between `min` and `max` (`amount > (max - min + 1)`), function returns an empty array (`[]`).
+
+`param {Number} amount: Total number of indexes to be generated`
+
+`param {Number} min: Minimum value that indexes can have`
+
+`param {Number} max: Maximum value that indexes can have`
+
+```javascript
+const max = 5;
+const min = 1;
+const amount = 3;
+
+const randomInts = generateUniqueNumbers(amount, min, max);
+// [2, 3, 5]
+```

--- a/services/breakpoints.js
+++ b/services/breakpoints.js
@@ -1,0 +1,30 @@
+let breakpoints = {};
+
+export const matchMediaAvailable = (
+  typeof window !== 'undefined'
+  && typeof window.matchMedia === 'function'
+);
+
+export const mediaMatches = (breakpoint, {
+  matchMedia = matchMediaAvailable ? window.matchMedia : () => false,
+} = {}) => {
+  if (typeof breakpoints[breakpoint] === 'undefined') {
+    // Breakpoint not defined, we treat it as a media query string
+    return matchMedia(breakpoint).matches;
+  }
+
+  return matchMedia(breakpoints[breakpoint]).matches;
+};
+
+export const setBreakpoints = (newBreakpoints) => {
+  breakpoints = newBreakpoints;
+};
+
+export const getBreakpoints = () => breakpoints;
+
+export default {
+  matchMediaAvailable,
+  mediaMatches,
+  setBreakpoints,
+  getBreakpoints,
+};

--- a/services/date.js
+++ b/services/date.js
@@ -1,0 +1,57 @@
+// Sets date time to midnight for unifying purposes
+export const resetDateTime = (date) => {
+  const clonedDate = new Date(date);
+  clonedDate.setHours(0, 0, 0, 0);
+
+  return clonedDate;
+};
+
+// Returns date which is amountOfDays from the initialDate
+export const getNDaysFromDate = (initialDate, amountOfDays) => {
+  // Create a clone of initialDate in order not to edit it
+  const startDate = new Date(initialDate);
+  return resetDateTime(new Date(startDate.setDate(initialDate.getDate() + amountOfDays)));
+};
+
+export const convertMsToDays = ms => Math.round(ms / 1000 / 60 / 60 / 24);
+
+export const getDaysDateRange = (startDate, endDate) => {
+  const dateDiffDays = convertMsToDays(endDate.getTime() - startDate.getTime());
+  const datesArray = [];
+
+  /* eslint-disable no-plusplus  */
+  for (let day = 0; day < dateDiffDays; day++) {
+    datesArray.push(getNDaysFromDate(startDate, day));
+  }
+
+  return datesArray;
+};
+
+// Returns array of unique date strings from original array
+export const getIntlDateString = (locale, datesArray, localStringArgs) => datesArray.reduce((accumulator, currentItem) => {
+  const currentDay = new Date(currentItem).toLocaleString(
+    locale,
+    localStringArgs,
+  );
+  if (accumulator.indexOf(currentDay) === -1) accumulator.push(currentDay);
+
+  return accumulator;
+}, []);
+
+export const generateDateCycles = (cycleLengthWeeks, amountOfCycles, startDateOffset) => {
+  const WEEK_DAYS = 7;
+  const cycleLengthDays = cycleLengthWeeks * WEEK_DAYS;
+  const startDate = getNDaysFromDate(new Date(), startDateOffset);
+  const endDate = getNDaysFromDate(new Date(), (cycleLengthDays * amountOfCycles) + startDateOffset);
+
+  return getDaysDateRange(startDate, endDate);
+};
+
+export default {
+  resetDateTime,
+  getNDaysFromDate,
+  convertMsToDays,
+  getDaysDateRange,
+  getIntlDateString,
+  generateDateCycles,
+};

--- a/services/event-emitter.js
+++ b/services/event-emitter.js
@@ -1,0 +1,5 @@
+import Vue from 'vue';
+
+const EventEmitter = new Vue();
+
+export default EventEmitter;

--- a/services/flickity.js
+++ b/services/flickity.js
@@ -1,0 +1,16 @@
+export function hidePaginationWhenNotNeeded() {
+  const viewport = this.size.width;
+  const fullSize = Math.round(this.slideableWidth);
+
+  if (fullSize > viewport) {
+    this.bindDrag();
+    this.element.classList.remove('flickity--no-controls');
+  } else if (fullSize <= viewport) {
+    this.unbindDrag();
+    this.element.classList.add('flickity--no-controls');
+  }
+}
+
+export default {
+  hidePaginationWhenNotNeeded,
+};

--- a/services/formValidation.js
+++ b/services/formValidation.js
@@ -1,0 +1,16 @@
+export function email(string) {
+  // eslint-disable-next-line
+  const regex = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+  return regex.test(string.toLowerCase());
+}
+
+export function date(string) {
+  // eslint-disable-next-line
+  const regex = /[0-9]{4}-[0-9]{2}-[0-9]{2}/;
+  return regex.test(string);
+}
+
+export default {
+  email,
+  date,
+};

--- a/services/googleAPI.js
+++ b/services/googleAPI.js
@@ -1,0 +1,24 @@
+import { loadScript } from 'homeday-blocks/src/services/utils';
+
+let mapsApiPromise = null;
+
+export function getGoogleAPI(key) {
+  if (mapsApiPromise) {
+    return mapsApiPromise;
+  }
+
+  mapsApiPromise = new Promise((resolve) => {
+    loadScript({
+      url: `https://maps.googleapis.com/maps/api/js?v=3.37&key=${key}&libraries=places&region=DE`,
+    }).then(() => {
+      resolve(window.google);
+    }).catch(() => {
+      mapsApiPromise = null;
+    });
+  });
+  return mapsApiPromise;
+}
+
+export default {
+  getGoogleAPI,
+};

--- a/services/on-resize.js
+++ b/services/on-resize.js
@@ -1,0 +1,35 @@
+import EventEmitter from 'homeday-blocks/src/services/event-emitter';
+import throttle from 'lodash/throttle';
+import debounce from 'lodash/debounce';
+
+const throttledResize = throttle(() => {
+  EventEmitter.$emit('resize.throttled');
+}, 100);
+const debouncedResize = debounce(() => {
+  EventEmitter.$emit('resize.debounced');
+}, 300);
+
+window.addEventListener('resize', () => {
+  throttledResize();
+  debouncedResize();
+}, false);
+
+window.addEventListener('orientationchange', () => {
+  throttledResize();
+  debouncedResize();
+}, false);
+
+export default {
+  onThrottled: (cb) => {
+    EventEmitter.$on('resize.throttled', cb);
+  },
+  offThrottled: (cb) => {
+    EventEmitter.$off('resize.throttled', cb);
+  },
+  onDebounced: (cb) => {
+    EventEmitter.$on('resize.debounced', cb);
+  },
+  offDebounced: (cb) => {
+    EventEmitter.$off('resize.debounced', cb);
+  },
+};

--- a/services/scrolling.js
+++ b/services/scrolling.js
@@ -1,0 +1,113 @@
+import naturalScroll from 'natural-scroll';
+import {
+  disableBodyScroll,
+  enableBodyScroll,
+} from 'body-scroll-lock';
+
+export function elOffset(el) {
+  const box = el.getBoundingClientRect();
+  const clientTop = document.clientTop || document.body.clientTop || 0;
+  const clientLeft = document.clientLeft || document.body.clientLeft || 0;
+  const scrollTop = window.pageYOffset || document.scrollTop || 0;
+  const scrollLeft = window.pageXOffset || document.scrollLeft || 0;
+
+  return {
+    top: box.top + (scrollTop - clientTop),
+    left: box.left + (scrollLeft - clientLeft),
+    width: box.width,
+    height: box.height,
+  };
+}
+
+export function getDocumentHeight() {
+  return Math.max(
+    document.body.scrollHeight, document.documentElement.scrollHeight,
+    document.body.offsetHeight, document.documentElement.offsetHeight,
+    document.body.clientHeight, document.documentElement.clientHeight,
+  );
+}
+
+export function isWindowFullyScrolled() {
+  if (window.pageYOffset + document.documentElement.clientHeight >= getDocumentHeight()) {
+    return true;
+  }
+
+  return false;
+}
+
+export function freezeScrolling(el) {
+  // eslint-disable-next-line no-param-reassign
+  el.style['-webkit-overflow-scrolling'] = 'touch';
+  disableBodyScroll(el);
+}
+
+export function unfreezeScrolling(el) {
+  // eslint-disable-next-line no-param-reassign
+  el.style['-webkit-overflow-scrolling'] = 'auto';
+  enableBodyScroll(el);
+}
+
+export function isElVisible({ el, offset = 0 }) {
+  if (el == null) {
+    return false;
+  }
+
+  const { top: offsetTop } = elOffset(el);
+
+  if (offsetTop < window.pageYOffset + offset) {
+    return false;
+  }
+
+  if (offsetTop > window.pageYOffset + window.innerHeight) {
+    return false;
+  }
+
+  return true;
+}
+
+export function isScrolledPastElBottom({
+  el,
+  // The default offset will check whether we reached the bottom of the element
+  // with the bottom edge of the screen
+  offset = window.innerHeight,
+}) {
+  if (el == null) {
+    return false;
+  }
+
+  const { top: offsetTop } = elOffset(el);
+
+  const elBottom = offsetTop + el.clientHeight;
+
+  if (elBottom > window.pageYOffset + offset) {
+    return false;
+  }
+
+  return true;
+}
+
+export function scrollToEl({ el, offset = 0, onlyIfNotVisible = true }) {
+  const toScroll = [
+    document.documentElement,
+    document.body,
+  ];
+
+  if (el == null || (onlyIfNotVisible && isElVisible({ el, offset }))) {
+    return;
+  }
+
+  toScroll.forEach((toScrollEl) => {
+    naturalScroll.scrollTop(toScrollEl, elOffset(el).top - offset);
+  });
+}
+
+export default {
+  elOffset,
+  getDocumentHeight,
+  isWindowFullyScrolled,
+  freezeScrolling,
+  unfreezeScrolling,
+  isElVisible,
+  isScrolledPastElBottom,
+  scrollToEl,
+};

--- a/services/utils.js
+++ b/services/utils.js
@@ -1,0 +1,132 @@
+/* eslint-disable */
+import merge from 'lodash/merge';
+
+const accentMap = {
+  'ä': 'a',
+  'ö': 'o',
+  'ü': 'u',
+  'ß': 'ss'
+};
+
+// Replaces all occurances of accents from the accentMap
+export const accentFold = string => string.split('').map(char => {
+  return accentMap[char] ? accentMap[char] : char;
+}).join('');
+
+
+/** Replace all the occurrences in a string */
+export function populateTemplate(template, map) {
+  const regex = new RegExp(`(${Object.keys(map).map(k => `:${k}`).join('|')})`, 'g');
+  return template.replace(regex, match => map[match.slice(1)]);
+}
+
+/** Takes a data object and returns a nested object based on the keys and the nestingString
+*/
+export function formatNestedData(data, nestingString = '.') {
+  const formattedObj = {};
+  Object.keys(data).forEach((fieldKey) => {
+    const value = data[fieldKey];
+    const keys = fieldKey.split(nestingString);
+    const nestedSubObj = keys.reverse().reduce((acc, currentKey, index) => {
+      if (index === 0) {
+        acc[currentKey] = value;
+        return acc;
+      }
+      acc = merge({}, { [currentKey]: acc });
+      return acc;
+    }, {});
+    merge(formattedObj, nestedSubObj);
+  });
+  return formattedObj;
+}
+
+/** Returns the level of password strength in a range of [0 - (levelsCount - 1)] */
+export function getPasswordStrength(password, levelsCount) {
+  const MAX_POINTS = 4; // The number of points required to get the highest strength level
+
+  const minimumLength = (string) => {
+    const MINIMUM_LENGTH = 8;
+    const LENGTH_BONUS_STEP = 5;
+    const stringLength = string.length;
+
+    if (stringLength >= MINIMUM_LENGTH) {
+      return Math.floor((stringLength - MINIMUM_LENGTH) / LENGTH_BONUS_STEP) + 1;
+    }
+    return 0;
+  };
+  const number = string => /\d/.test(string) ? 1 : 0;
+  const upperAndLowcase = string => string.toUpperCase() !== string && string.toLowerCase() !== string ? 1 : 0;
+  const specialCharacter = string => /[~`!#$%\^&*+=\-\[\]\\';,/{}|\\":<>\?]/g.test(string) ? 1 : 0;
+
+  const rules = [
+    minimumLength,
+    number,
+    upperAndLowcase,
+    specialCharacter,
+  ];
+
+  let passedRules = 0;
+  rules.forEach((rule) => {
+    passedRules += rule(password);
+  });
+  passedRules = passedRules > MAX_POINTS ? MAX_POINTS : passedRules;
+  return Math.floor((passedRules / MAX_POINTS) * (levelsCount - 1));
+}
+
+// Generates random integer based on provided min and max
+export const getRandomInt = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min;
+
+export const circleToPath = (cx, cy, r) => `M ${cx} ${cy} m -${r}, 0 a ${r},${r} 0 1,0 ${r * 2},0 a ${r},${r} 0 1,0 -${r * 2},0`;
+
+// Returns an array of the desired length filled with indexes as values
+export function getArrayOfSize(size = 0) {
+  return Array.from(Array(size), (_, x) => x);
+}
+
+export function loadScript({ url = '', first = false, head = false }) {
+  return new Promise((resolve) => {
+    const script = document.createElement('script');
+    script.onload = resolve;
+    script.type = 'text/javascript';
+    script.src = url;
+
+    const parent = document[head ? 'head' : 'body'];
+    if (first) {
+      parent.insertBefore(script, parent.firstChild);
+    } else {
+      parent.appendChild(script);
+    }
+  });
+}
+
+// Returns list of random integers
+export const generateUniqueNumbers = (amount, min, max) => {
+  const indexes = [];
+  // sanity check to prevent infinit loop
+  if (amount > (max - min + 1)) {
+    return indexes;
+  }
+  // max tries are arbitrary selected attempts limit
+  // to prevent super expensive cases of finding all
+  // unique numbers
+  let maxTries = 10 * amount;
+  while (indexes.length < amount && maxTries > 0) {
+    maxTries -= 1;
+    const randomInt = getRandomInt(min, max);
+    if (!indexes.includes(randomInt)) {
+      indexes.push(randomInt);
+    }
+  }
+  return indexes;
+};
+
+export default {
+  populateTemplate,
+  getPasswordStrength,
+  formatNestedData,
+  getRandomInt,
+  accentFold,
+  getArrayOfSize,
+  loadScript,
+  generateUniqueNumbers,
+};

--- a/src/stories/HdCalendar.stories.js
+++ b/src/stories/HdCalendar.stories.js
@@ -1,8 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from '@storybook/vue';
 import { action } from '@storybook/addon-actions';
-import { generateDateCycles } from 'homeday-blocks/src/services/date';
-
+import { generateDateCycles } from 'homeday-blocks/services/date';
 import HdCalendar from 'homeday-blocks/src/components/HdCalendar.vue';
 
 storiesOf('HdCalendar', module)

--- a/tests/unit/services/date.spec.js
+++ b/tests/unit/services/date.spec.js
@@ -5,7 +5,7 @@ import {
   getDaysDateRange,
   getIntlDateString,
   generateDateCycles,
-} from '@/services/date';
+} from 'homeday-blocks/services/date';
 
 
 describe('Date service', () => {


### PR DESCRIPTION
## Proposal

*For now you can ignore CI and so on*

- Moved services to root folder
  - **From**: \<rootDir\>/src/services
  - **To**: \<rootDir\>/services
- New way of importing services, so you don't need to fully import the service anymore
  - **From**
```javascript
import { DateService } from 'homeday-blocks';

const { generateDateCycles } = DateService; // or just use DateService.generateDateCycles
```
  - **To**
```javascript
import { generateDateCycles } from 'homeday-blocks/services/date';
```

### Advantage
- We can import just the function we need/want so we don't import the full service

### Disadvantage
- Some refactoring + breaking change
- [Mess(i)](https://sportbild.bild.de/fotos-skaliert/wird-gegen-inter-fehlen-barca-superstar-lionel-messi-201307831-66582448/2,w=993,c=0.sport.jpg) folder structure as `services` won't live inside `src` anymore
  - Regarding this we can think about moving other stuffs outside the `src` folder. We could have `homeday-blocks/components/form/HdInput` for example but that is not the goal of this PR (open for discussion though) 