### PR TITLE
[B] Fix HdGallery & HdGalleryCarousel

### DIFF
--- a/src/components/gallery/HdGalleryCarousel.vue
+++ b/src/components/gallery/HdGalleryCarousel.vue
@@ -148,9 +148,9 @@ export default {
         this.updateCurrentIndex();
       });
     },
-    updateCurrentIndex(itemIndex) {
-      this.currentIndex = itemIndex;
-      this.$emit('input', itemIndex);
+    updateCurrentIndex() {
+      this.currentIndex = this.value;
+      this.$emit('input', this.currentIndex);
     },
     onStaticClick(event, pointer, cellElement, cellIndex) {
       if (typeof cellIndex === 'undefined') {

--- a/src/components/gallery/HdGalleryCarousel.vue
+++ b/src/components/gallery/HdGalleryCarousel.vue
@@ -148,8 +148,8 @@ export default {
         this.updateCurrentIndex();
       });
     },
-    updateCurrentIndex() {
-      this.currentIndex = this.value;
+    updateCurrentIndex(itemIndex) {
+      this.currentIndex = itemIndex;
       if (window.matchMedia('min-width: $break-tablet')) {
         this.$emit('input', itemIndex);
       }

--- a/src/components/gallery/HdGalleryCarousel.vue
+++ b/src/components/gallery/HdGalleryCarousel.vue
@@ -150,7 +150,9 @@ export default {
     },
     updateCurrentIndex() {
       this.currentIndex = this.value;
-      this.$emit('input', this.currentIndex);
+      if (window.matchMedia('min-width: $break-tablet')) {
+        this.$emit('input', itemIndex);
+      }
     },
     onStaticClick(event, pointer, cellElement, cellIndex) {
       if (typeof cellIndex === 'undefined') {


### PR DESCRIPTION
https://homeday.atlassian.net/browse/FET-133

This one is a bit strange, would appreciate more input here. What I've notice is that `change` event is called only when we are at the end of the carousel and index reported in the event is always wrong (`0` or `1`). 

I assume, as we're handling index outside of here, that when we're looping through the images, the flickity is not aware of the changes and kicks in when carousel needs to move and therefore screams the wrong index. 

Disclaimer: I'm not that familiar with Flickity, however look at the docs, our `change`, is definitely not behaving as expected - https://flickity.metafizzy.co/events.html#change and example here: https://codepen.io/desandro/pen/ZxpMdY

I think we might want to look in to this deeper. For the time being, I think this might fix the issue (not the nicest indeed). The logic is to "fix" the index, when flickity gets involved. Can someone try it in real life use case? Thanks! 