### PR TITLE
[T] Remove input filled darker background

### DIFF
--- a/src/components/form/HdSplitInput.vue
+++ b/src/components/form/HdSplitInput.vue
@@ -209,9 +209,7 @@ export default {
       color: getShade($quaternary-color, 80);
       font-size: 20px;
       font-weight: 700;
-      #{$f}--filled:not(#{$f}--active):not(#{$f}--invalid) & {
-        background-color: $inputFilledBackground;
-      }
+
       &__symbol {
         margin-top: $stack-m;
       }

--- a/src/styles/inputs.scss
+++ b/src/styles/inputs.scss
@@ -3,8 +3,6 @@ $iconDimension: 24px;
 $innerIconDimension: 18px;
 $inputLeftPadding: $inline-s;
 $inputBackground: $secondary-bg;
-// TODO: Use a design system value instead of `darken`
-$inputFilledBackground: darken($secondary-bg, 5);
 $inputPaddingTop: $labelHeight + $stack-xs;
 $focusedLabelTop: 5px;
 
@@ -74,10 +72,6 @@ $focusedLabelTop: 5px;
       display: block;
       z-index: 1;
       pointer-events: none;
-    }
-
-    &#{$f}--filled:not(#{$f}--active):not(#{$f}--invalid):before {
-      background: $inputFilledBackground;
     }
 
     &#{$f}--hasIcon:before {
@@ -336,9 +330,6 @@ $focusedLabelTop: 5px;
     &::-ms-reveal {
       display: none;
     }
-    #{$f}--filled:not(#{$f}--active):not(#{$f}--invalid) & {
-      background: $inputFilledBackground;
-    }
 
     #{$f}--disabled & {
       color: getShade($quaternary-color, 70);
@@ -434,9 +425,7 @@ $focusedLabelTop: 5px;
       background: $inputBackground;
       left: calc(50% - 8px);
     }
-    #{$f}--filled:not(#{$f}--active):not(#{$f}--invalid) &:before {
-      background: $inputFilledBackground;
-    }
+
     &:after {
       content: "";
       position: absolute;


### PR DESCRIPTION
Some context: https://homeday.atlassian.net/browse/FET-140

---

Currently we keep a darker background once the input is filled. As discussed between us and designers it is not the desired state once we don't even keep it like that in Figma.
To avoid conflicts between Figma designs and implementation we agreed on removing the darker background.