### PR TITLE
[F] Default breakpoints for the responsive service

### DIFF
--- a/src/services/breakpoints.js
+++ b/src/services/breakpoints.js
@@ -1,26 +1,36 @@
-let breakpoints = {};
+import sassVariables from 'homeday-blocks/src/styles/variablesForJS.scss';
 
-export const matchMediaAvailable = (
-  typeof window !== 'undefined'
-  && typeof window.matchMedia === 'function'
-);
+let breakpoints = {
+  mobile: `(max-width: ${sassVariables.breakMobile - 1}px)`,
+  tablet: `(min-width: ${sassVariables.breakMobile}px)`,
+  desktop: `(min-width: ${sassVariables.breakTablet}px)`,
+  desktopWide: `(min-width: ${sassVariables.breakDesktop}px)`,
+  desktopExtraWide: `(min-width: ${sassVariables.breakDesktopWide}px)`,
+};
 
-export const mediaMatches = (breakpoint, {
-  matchMedia = matchMediaAvailable ? window.matchMedia : () => false,
-} = {}) => {
+export const matchMediaAvailable = window && typeof window.matchMedia === 'function';
+
+const defaultMatchMedia = matchMediaAvailable ? window.matchMedia : () => false;
+
+export function mediaMatches(
+  breakpoint,
+  { matchMedia = defaultMatchMedia } = {},
+) {
   if (typeof breakpoints[breakpoint] === 'undefined') {
     // Breakpoint not defined, we treat it as a media query string
     return matchMedia(breakpoint).matches;
   }
 
   return matchMedia(breakpoints[breakpoint]).matches;
-};
+}
 
-export const setBreakpoints = (newBreakpoints) => {
+export function setBreakpoints(newBreakpoints) {
   breakpoints = newBreakpoints;
-};
+}
 
-export const getBreakpoints = () => breakpoints;
+export function getBreakpoints() {
+  return breakpoints;
+}
 
 export default {
   matchMediaAvailable,

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -4,15 +4,15 @@
 
 
 @mixin only-ie {
-    @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-        @content;
-    }
+  @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+    @content;
+  }
 }
 
 @function strip-unit($number) {
-    @if type-of($number) == 'number' and not unitless($number) {
-      @return $number / ($number * 0 + 1);
-    }
-  
-    @return $number;
+  @if type-of($number) == 'number' and not unitless($number) {
+    @return $number / ($number * 0 + 1);
   }
+
+  @return $number;
+}

--- a/src/styles/variablesForJS.scss
+++ b/src/styles/variablesForJS.scss
@@ -1,8 +1,8 @@
-@import './variables';
+@import './mixins';
 
 :export {
-  breakMobile : $break-mobile;
-  breakTablet : $break-tablet;
-  breakDesktop : $break-desktop;
-  breakDesktopWide : $break-desktop-wide;
+  breakMobile : strip-unit($break-mobile);
+  breakTablet : strip-unit($break-tablet);
+  breakDesktop : strip-unit($break-desktop);
+  breakDesktopWide : strip-unit($break-desktop-wide);
 }


### PR DESCRIPTION
https://homeday.atlassian.net/browse/FET-146

While working on this one I noticed that we might want to discuss breakpoints in our upcoming DS meeting.
Because it seems to me like they weren't set with "mobile-first" in mind.

For example with this:
```
$break-mobile: 460px !default;
$break-tablet: 768px !default;
```
**is `500px` mobile or not?**
if it is, then we should probably get rid of `$break-mobile` and consider anything under `768px` to be mobile.
if it's not, then we should adapt the naming from `$break-mobile` to `$break-tablet`, `$break-tablet` to `$break-desktop`... and so on. (this is the approach I took in the responsive service breakpoints, that's why I ended up with `desktopExtraWide`).

`$break-mobile` doesn't make sense in mobile-first projects.

Check how we are doing it in [customer-app](https://github.com/homeday-de/customer-app/blob/develop/src/styles/breakpoints.scss) and [realtor-app](https://github.com/homeday-de/realtor-app/blob/develop/src/styles/breakpoints.scss).