### PR TITLE
[F] HdDynamicForm more field column flexibility

### DIFF
--- a/src/components/form/HdDynamicForm.vue
+++ b/src/components/form/HdDynamicForm.vue
@@ -2,17 +2,37 @@
   <form class="dynamicForm" @submit.prevent="submit" novalidate>
     <slot name="before"/>
     <div v-for="(line, i) in lines" class="dynamicForm__line" :key="`line-${i}`">
+      <template v-for="(item, index) in getItemsArray(line)">
+        <div
+        v-if="Array.isArray(item)"
+        class="dynamicForm__line__item dynamicForm__line__item--with-subitems"
+        :key="`input-array-${index}`"
+        >
+          <component
+            v-for="subItem in item"
+            ref="fields"
+            :is="getComponent(subItem.type)"
+            :key="`input-${subItem.name}`"
+            v-model="formData[subItem.name]"
+            v-bind="subItem.props"
+            :name="subItem.name"
+            class="dynamicForm__line__item"
+            :lang="lang"
+            />
+        </div>
+
       <component
-      v-for="item in getItemsArray(line)"
-      ref="fields"
-      :is="getComponent(item.type)"
-      :key="`input-${item.name}`"
-      v-model="formData[item.name]"
-      v-bind="item.props"
-      :name="item.name"
-      class="dynamicForm__line__item"
-      :lang="lang"
+        v-else
+        ref="fields"
+        :is="getComponent(item.type)"
+        :key="`input-${item.name}`"
+        v-model="formData[item.name]"
+        v-bind="item.props"
+        :name="item.name"
+        class="dynamicForm__line__item"
+        :lang="lang"
       />
+    </template>
     </div>
     <slot name="before-button"/>
     <HdButton
@@ -152,6 +172,10 @@ export default {
       }
       &:last-of-type {
         margin-right: 0;
+      }
+
+      &--with-subitems {
+        display: flex;
       }
     }
   }


### PR DESCRIPTION
**The Context**
When configuring a dynamic form, one can pass an array as an item in order to group multiple fields in one line. Example:
```
export default function getConfigWith111Layout() {
  return [
    {...fieldA},
    {...fieldB},
    [
       {...fieldC1},
       {...fieldC2},
       {...fieldC3}
    ]
  ]
}
```

**The Problem**
However, these fields would always be flexed equally on the line (1-1-1), so one cannot create other layouts (e.g. 2-1-1 or 1-1-2). This limits our design implementation possibilities.

**The Solution**
By simply allowing one more level of array nesting in the `items` prop, we can allow to easily produce 2-1-1 and 1-1-2 layouts, by simply doing something like this:

```
export default function getConfigWith211Layout() {
  return [
    {...fieldA},
    {...fieldB},
    [
       {...fieldC1},
       [
         {...fieldC2},
         {...fieldC3}
       ]
    ]
  ]
}
```

**Up For Discussion**

- How does this fit in the upcoming grid system?

- Am I missing some horrible edge case here?


_I should note that this is a requirement for us to implement the layout for the new Profile Page on myHomeday https://homeday.atlassian.net/browse/CE-602_
