### PR TITLE
[T] Add changelog action

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,20 @@
+name: Changelog Generator
+on:
+  # Trigger the workflow on pull request,
+  # but only for the master branch
+  pull_request:
+    branches:
+      - master
+    types: [opened, reopened, synchronize]
+
+jobs:
+  changelog:
+    # Job name is Changelog
+    name: Changelog Generator
+    # This job runs on Linux
+    runs-on: ubuntu-latest
+    steps:
+        - uses: actions/checkout@v2
+        - uses: homeday-de/github-action-changelog-generator@v1.0.0
+          with:
+            token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://homeday.atlassian.net/browse/FET-137

You can find the source of action here: https://github.com/homeday-de/github-action-changelog-generator

There's still some debt to solve there, I'm tracking it with issues atm. Can be for version 2. :) 

There are some assumptions made in this action, that you can find here: https://github.com/homeday-de/github-action-changelog-generator/blob/develop/README.md


For testing purposes I pushed the branch to `upstream` as well and open a PR directly to `master`. You can see the result here #358 . It will look nicer, once we start following the conventions. Docs to follow (not in this PR).

Open for feedback.