### PR TITLE
[T] Add contribution and release documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,44 @@ You can also follow build statuses in https://percy.io/Homeday/homeday-blocks
 - `tests/` is an alias for `<rootDir>/tests/`
 - The form components share many classes (mostly `field--*`), to avoid repeatedly defining some of them in each form test, [FIELD_CLASSES.js](https://github.com/homeday-de/homeday-blocks/blob/develop/tests/unit/components/form/FIELD_CLASSES.js) contains the most common classes we need for testing. Feel free to add more classes.
 
-## Deployment
+## Contribution guide
 
-The [CI](https://travis-ci.com/homeday-de/homeday-blocks) will deploy storybook automatically to our [showcase env](https://blocks.homeday.dev), once PR is merged to `develop` branch. 
+Project follows [forking workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/forking-workflow). See [project setup](#project-setup) to get started locally. That means that all code changes enter the project by PR to `develop` branch. Once you open the PR with suggested changes the checks for `build` and `coverage` will run. If those fail, PR needs some more work. :) 
 
+Each PR should be reviewed by 2 team members. Once reviewed and approved,it can be merged. Please follow the following convention when merging the PR: 
+
+1) Use "Squash and merge" to merge the PR. 
+2) Use a meaningful title when merging your PR. 
+3) Give title a semantic meaning through [emojis](https://gitmoji.carloscuesta.me/). Please use emoji first, then the text. 
+4) **:boom: - marks breaking changes (MAJOR version change)** 
+5) **:sparkles: - marks new feature (MINOR version change)**
+6) Everything else is consider a patch change.
+
+It is important to follow this convention, because it makese generating changelog much easier (automatic). We use [changelog github action](https://github.com/homeday-de/github-action-changelog-generator) to automatically generate the changelog. Please see the link for more details on supported conventions. 
+
+#### Examples 
+
+##### Major change
+:boom: Removed HdNotNeeded component (#32)
+
+##### Minor change
+:sparkles: Added HdAwesomeComponent (#33)
+
+##### Patch
+:wrench: Updated travis configuration and run lint on build(#34)
+
+## Version release
+
+When new version is ready to be released, those are the steps we need to take:
+
+1) Create a release PR from `develop` to `master`
+2) Changelog will be generated during the checks. Check it to determed the release type - `MAJOR`, `MINOR` or `PATCH`.For more info, please see [contribuiton guide](#contribution-guide). If in doubt, consult with rest of the team. 
+3) Create a version bump PR to develop (use [`npm version`](https://docs.npmjs.com/cli/version.html) to make sure version is updated everywhere). This should be merged as last PR before releasing.
+4) Once version bump PR is merged to `develop` and all changes on release PR have passed, merged the release PR. 
+5) Draft a github release with corresponding version (target `master` branch) and publish it, including the before generate chanelog. Version naming convention is `vx.x.x`.
+6) Double check that new version has been automatically published on [npm registry]( https://www.npmjs.com/package/homeday-blocks)
+
+The [CI](https://travis-ci.com/homeday-de/homeday-blocks) will deploy storybook automatically to our [showcase env](https://blocks.homeday.dev), once PR is merged to `master` branch. 
 
 ## Consuming in other projects
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Each PR should be reviewed by 2 team members. Once reviewed and approved,it can 
 5) **:sparkles: - marks new feature (MINOR version change)**
 6) Everything else is consider a patch change.
 
-It is important to follow this convention, because it makese generating changelog much easier (automatic). We use [changelog github action](https://github.com/homeday-de/github-action-changelog-generator) to automatically generate the changelog. Please see the link for more details on supported conventions. 
+It is important to follow this convention, because it makes generating changelog much easier (automatic). We use [changelog github action](https://github.com/homeday-de/github-action-changelog-generator) to automatically generate the changelog. Please see the link for more details on supported conventions. 
 
 #### Examples 
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ When new version is ready to be released, those are the steps we need to take:
 1) Create a release PR from `develop` to `master`
 2) Changelog will be generated during the checks. Check it to determed the release type - `MAJOR`, `MINOR` or `PATCH`.For more info, please see [contribuiton guide](#contribution-guide). If in doubt, consult with rest of the team. 
 3) Create a version bump PR to develop (use [`npm version`](https://docs.npmjs.com/cli/version.html) to make sure version is updated everywhere). This should be merged as last PR before releasing.
-4) Once version bump PR is merged to `develop` and all changes on release PR have passed, merged the release PR. 
+4) Once version bump PR is merged to `develop` and all changes on release PR have passed, merge the release PR. 
 5) Draft a github release with corresponding version (target `master` branch) and publish it, including the before generate chanelog. Version naming convention is `vx.x.x`.
 6) Double check that new version has been automatically published on [npm registry]( https://www.npmjs.com/package/homeday-blocks)
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You can also follow build statuses in https://percy.io/Homeday/homeday-blocks
 - `tests/` is an alias for `<rootDir>/tests/`
 - The form components share many classes (mostly `field--*`), to avoid repeatedly defining some of them in each form test, [FIELD_CLASSES.js](https://github.com/homeday-de/homeday-blocks/blob/develop/tests/unit/components/form/FIELD_CLASSES.js) contains the most common classes we need for testing. Feel free to add more classes.
 
-## Contribution Guide
+## Contribution guide
 
 This project follows [forking workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/forking-workflow). See [project setup](#project-setup) to get started locally. That means that all code changes enter the project by PR to `develop` branch. Once you open the PR with suggested changes, the checks for `build` and `coverage` will run. If those fail, your PR needs some more work. :) 
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ You can also follow build statuses in https://percy.io/Homeday/homeday-blocks
 
 This project follows [forking workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/forking-workflow). See [project setup](#project-setup) to get started locally. That means that all code changes enter the project by PR to `develop` branch. Once you open the PR with suggested changes, the checks for `build` and `coverage` will run. If those fail, your PR needs some more work. :) 
 
-Each PR should be reviewed by at least two team members. Once reviewed and approved,it can be merged. Please follow the following convention when merging the PR: 
+Each PR should be reviewed by at least two team members. Once reviewed and approved, it can be merged. Please follow the following convention when merging the PR: 
 
 1) Use "Squash and merge" to merge the PR. 
 2) Use a meaningful title when merging your PR. 
@@ -106,7 +106,7 @@ Each PR should be reviewed by at least two team members. Once reviewed and appro
 5) **:sparkles: - marks new feature (MINOR version change)**
 6) Everything else is consider a patch change.
 
-It is important to follow this convention, because it makese generating changelog much easier (automatic). We use [changelog github action](https://github.com/homeday-de/homeday-blocks/blob/develop/.github/workflows/changelog.yml) to automatically generate the changelog. Please see [the link](https://github.com/homeday-de/github-action-changelog-generator) for more details on supported conventions. 
+It is important to follow this convention, because it makese generating changelog much easier (automatic). We use [changelog github action](https://github.com/homeday-de/homeday-blocks/blob/develop/.github/workflows/changelog.yml) to automatically generate the changelog. Please see [the action documentation](https://github.com/homeday-de/github-action-changelog-generator) for more details on supported conventions. 
 
 #### Examples 
 
@@ -127,7 +127,7 @@ When a new version is ready to be released, these are the steps we need to take:
 2) Changelog will be generated during the checks. Check it to determed the release type - `MAJOR`, `MINOR` or `PATCH`.For more info, please see [contribuiton guide](#contribution-guide). If in doubt, consult with rest of the team. 
 3) Create a version bump PR to develop (use [`npm version`](https://docs.npmjs.com/cli/version.html) to make sure version is updated everywhere). This should be merged as last PR before releasing.
 4) Once version bump PR is merged to `develop` and all checks on release PR have passed, merge the release PR. 
-5) Draft a github release with corresponding version (target `master` branch),include the generated changelog, and publish it. Version naming convention is `vx.x.x`.
+5) Draft a github release with corresponding version (target `master` branch), include the generated changelog, and publish it. Version naming convention is `vx.x.x`.
 6) After publishing the release on github, new version will be published automatically to the npm registry ([using github action](https://github.com/homeday-de/homeday-blocks/blob/develop/.github/workflows/publish.yml)) that's hooked to the [release event](https://developer.github.com/v3/activity/events/types/#releaseevent). Double check that the new version has been correctly published on [npm registry]( https://www.npmjs.com/package/homeday-blocks)
 
 The [CI](https://travis-ci.com/homeday-de/homeday-blocks) will automatically deploy the storybook to our [showcase env](https://blocks.homeday.dev), once the PR is merged to `master` branch. 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Each PR should be reviewed by at least two team members. Once reviewed and appro
 5) **:sparkles: - marks new feature (MINOR version change)**
 6) Everything else is consider a patch change.
 
-It is important to follow this convention, because it makes generating changelog much easier (automatic). We use [changelog github action](https://github.com/homeday-de/github-action-changelog-generator) to automatically generate the changelog. Please see the link for more details on supported conventions. 
+It is important to follow this convention, because it makese generating changelog much easier (automatic). We use [changelog github action](https://github.com/homeday-de/homeday-blocks/blob/develop/.github/workflows/changelog.yml) to automatically generate the changelog. Please see [the link](https://github.com/homeday-de/github-action-changelog-generator) for more details on supported conventions. 
 
 #### Examples 
 
@@ -126,9 +126,9 @@ When a new version is ready to be released, these are the steps we need to take:
 1) Create a release PR from `develop` to `master`
 2) Changelog will be generated during the checks. Check it to determed the release type - `MAJOR`, `MINOR` or `PATCH`.For more info, please see [contribuiton guide](#contribution-guide). If in doubt, consult with rest of the team. 
 3) Create a version bump PR to develop (use [`npm version`](https://docs.npmjs.com/cli/version.html) to make sure version is updated everywhere). This should be merged as last PR before releasing.
-4) Once version bump PR is merged to `develop` and all changes on release PR have passed, merge the release PR. 
-5) Draft a github release with corresponding version (target `master` branch), include the generated changelog, and publish it. Version naming convention is `vx.x.x`.
-6) Double check that the new version has been automatically published on [npm registry]( https://www.npmjs.com/package/homeday-blocks)
+4) Once version bump PR is merged to `develop` and all checks on release PR have passed, merge the release PR. 
+5) Draft a github release with corresponding version (target `master` branch),include the generated changelog, and publish it. Version naming convention is `vx.x.x`.
+6) After publishing the release on github, new version will be published automatically to the npm registry ([using github action](https://github.com/homeday-de/homeday-blocks/blob/develop/.github/workflows/publish.yml)) that's hooked to the [release event](https://developer.github.com/v3/activity/events/types/#releaseevent). Double check that the new version has been correctly published on [npm registry]( https://www.npmjs.com/package/homeday-blocks)
 
 The [CI](https://travis-ci.com/homeday-de/homeday-blocks) will automatically deploy the storybook to our [showcase env](https://blocks.homeday.dev), once the PR is merged to `master` branch. 
 

--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ You can also follow build statuses in https://percy.io/Homeday/homeday-blocks
 - `tests/` is an alias for `<rootDir>/tests/`
 - The form components share many classes (mostly `field--*`), to avoid repeatedly defining some of them in each form test, [FIELD_CLASSES.js](https://github.com/homeday-de/homeday-blocks/blob/develop/tests/unit/components/form/FIELD_CLASSES.js) contains the most common classes we need for testing. Feel free to add more classes.
 
-## Contribution guide
+## Contribution Guide
 
-Project follows [forking workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/forking-workflow). See [project setup](#project-setup) to get started locally. That means that all code changes enter the project by PR to `develop` branch. Once you open the PR with suggested changes the checks for `build` and `coverage` will run. If those fail, PR needs some more work. :) 
+This project follows [forking workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/forking-workflow). See [project setup](#project-setup) to get started locally. That means that all code changes enter the project by PR to `develop` branch. Once you open the PR with suggested changes, the checks for `build` and `coverage` will run. If those fail, your PR needs some more work. :) 
 
-Each PR should be reviewed by 2 team members. Once reviewed and approved,it can be merged. Please follow the following convention when merging the PR: 
+Each PR should be reviewed by at least two team members. Once reviewed and approved,it can be merged. Please follow the following convention when merging the PR: 
 
 1) Use "Squash and merge" to merge the PR. 
 2) Use a meaningful title when merging your PR. 
@@ -121,16 +121,16 @@ It is important to follow this convention, because it makes generating changelog
 
 ## Version release
 
-When new version is ready to be released, those are the steps we need to take:
+When a new version is ready to be released, these are the steps we need to take:
 
 1) Create a release PR from `develop` to `master`
 2) Changelog will be generated during the checks. Check it to determed the release type - `MAJOR`, `MINOR` or `PATCH`.For more info, please see [contribuiton guide](#contribution-guide). If in doubt, consult with rest of the team. 
 3) Create a version bump PR to develop (use [`npm version`](https://docs.npmjs.com/cli/version.html) to make sure version is updated everywhere). This should be merged as last PR before releasing.
 4) Once version bump PR is merged to `develop` and all changes on release PR have passed, merge the release PR. 
-5) Draft a github release with corresponding version (target `master` branch) and publish it, including the before generate chanelog. Version naming convention is `vx.x.x`.
-6) Double check that new version has been automatically published on [npm registry]( https://www.npmjs.com/package/homeday-blocks)
+5) Draft a github release with corresponding version (target `master` branch), include the generated changelog, and publish it. Version naming convention is `vx.x.x`.
+6) Double check that the new version has been automatically published on [npm registry]( https://www.npmjs.com/package/homeday-blocks)
 
-The [CI](https://travis-ci.com/homeday-de/homeday-blocks) will deploy storybook automatically to our [showcase env](https://blocks.homeday.dev), once PR is merged to `master` branch. 
+The [CI](https://travis-ci.com/homeday-de/homeday-blocks) will automatically deploy the storybook to our [showcase env](https://blocks.homeday.dev), once the PR is merged to `master` branch. 
 
 ## Consuming in other projects
 


### PR DESCRIPTION
https://homeday.atlassian.net/browse/FET-136

This PR adds documentation for release process and contribution. 
Please let me know if this is clear enough.

You can see the output version here: https://github.com/SinisaG/homeday-blocks/tree/docs/release#contribution-guide (easier to read)