### PR TITLE
[B] Fixing assets url on HdModal

### DIFF
--- a/src/components/HdModal.vue
+++ b/src/components/HdModal.vue
@@ -170,7 +170,7 @@ export default {
     position: absolute;
     top: $stack-s;
     right: $inline-s;
-    background: url('~@/assets/icons/ic_close.svg') no-repeat center / contain;
+    background: url('~homeday-blocks/src/assets/icons/ic_close.svg') no-repeat center / contain;
     width: 24px;
     height: 24px;
     padding: 0;
@@ -186,14 +186,14 @@ export default {
     #{$_root}--external-close-icon & {
       top: -24px;
       right: 0;
-      background: $primary-color url('~@/assets/icons/ic_close--white.svg');
+      background: $primary-color url('~homeday-blocks/src/assets/icons/ic_close--white.svg');
       background-position: center;
       background-size: contain;
       background-repeat: no-repeat;
     }
 
     &--light {
-      background: url('~@/assets/icons/ic_close--white.svg');
+      background: url('~homeday-blocks/src/assets/icons/ic_close--white.svg');
     }
   }
   &__inner {


### PR DESCRIPTION
Assets were returning error for projects using Homeday-blocks.

![image](https://user-images.githubusercontent.com/2879127/77736345-6125b100-700c-11ea-8533-45b5b60390c6.png)
