### PR TITLE
[B] Don't shrink HdAlert icons

### DIFF
--- a/src/components/HdAlert.vue
+++ b/src/components/HdAlert.vue
@@ -116,6 +116,7 @@ export default {
   &__icon {
     width: 24px;
     align-self: flex-start;
+    flex-shrink: 0;
     margin-top: $stack-xxs;
     margin-right: $inline-s;
 


### PR DESCRIPTION
@viniciuskneves discovered this bug:
<img alt="hdalert icon bug" src="https://user-images.githubusercontent.com/30146019/79853455-62a68700-83c8-11ea-93c0-6c2d4f8c81c9.jpg" width="300">

As you can see when the message goes to more than one line, the icon shrinks (it should stay 24px*24px). This PR fixes that.