### PR TITLE
[T] Don't try to publish to Github packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to NPM and Github Packages
+name: Publish to NPM
 
 on:
   release:
@@ -17,16 +17,3 @@ jobs:
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
-
-  publish-gpr:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 10.19.0
-          registry-url: https://npm.pkg.github.com/
-      - run: npm ci
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
I left this code hoping that one day will start supporting Github Packages, but now I don't see us doing it anytime soon, especially after Github acquiring NPM (let's see what happens), so this code is giving us nothing but a failed action.