### PR TITLE
[F] Increase password security by adding a HIBP check

### DIFF
--- a/src/components/form/HdInputPassword.vue
+++ b/src/components/form/HdInputPassword.vue
@@ -25,6 +25,7 @@
 <script>
 import HdInput from 'homeday-blocks/src/components/form/HdInput.vue';
 import HdIcon from 'homeday-blocks/src/components/HdIcon.vue';
+import hasPasswordBeenPwnd from 'homeday-blocks/src/services/hibp';
 import { visibilityOnIcon } from 'homeday-blocks/src/assets/small-icons';
 
 export default {
@@ -58,6 +59,9 @@ export default {
     },
   },
   methods: {
+    hasPasswordBeenPwnd() {
+      return hasPasswordBeenPwnd(this.computedValue);
+    },
     toggleVisibility() {
       this.type = this.type === 'password' ? 'text' : 'password';
     },

--- a/src/components/form/HdPasswordConfirm.vue
+++ b/src/components/form/HdPasswordConfirm.vue
@@ -118,6 +118,9 @@ export default {
       }
       return isValid;
     },
+    hasPasswordBeenPwnd() {
+      return this.$refs.passwordMain.hasPasswordBeenPwnd(this.passwordMain);
+    },
     checkPasswordLength() {
       if (this.passwordMain.length === 0 && this.required) {
         this.$refs.passwordMain.showError(this.t.FORM.VALIDATION.REQUIRED);

--- a/src/services/hibp.js
+++ b/src/services/hibp.js
@@ -1,0 +1,88 @@
+/* eslint-disable no-use-before-define */
+// Documentation: https://haveibeenpwned.com/API/v3#PwnedPasswords
+
+/**
+ * hasPasswordBeenPwnd
+ * this is an entry point to the service and function wich controls the flow
+ * @param {String} text
+ * Returns boolean true or false, depending on api call results
+ * NOTE: If request fails for any reason (network error, unexpected status code),
+ * we swallow the error and return true. This is to prevent blocking the user flow
+ * if there are issue with the extenral service
+ */
+export default async function hasPasswordBeenPwnd(text) {
+  if (!canBeChecked(text)) {
+    return false;
+  }
+  const hash = await digestMessage(text);
+  try {
+    const result = await queryHIBP(hash);
+    return hasBeenPwnd(hash, result);
+  } catch (e) {
+    // to prevent breaking of the flow, we exit with false
+    return false;
+  }
+}
+
+/**
+ * Sanity check before executing the lookup
+ * In general, Crypto and TextEncoding are well supported in
+ * everygreen browsers. But IE does not support it.In order to prevent
+ * bloating of JS, we probably don't need to polyfil any of this
+ * @param {String} text
+ * Returns boolean - true if all the requierments are meet
+ */
+function canBeChecked(text) {
+  if (window.TextEncoder && window.crypto
+    && window.crypto.subtle && text.length > 0) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ *
+ * @param {String} hash - SHA-1 hash HEX representation of user passed input
+ * @param {Array} setOfPwds - Set of passwords the service returns, that
+ * need to be checked for the match with our user hash
+ * Returns boolean - true in case the password has been comprimised
+ */
+function hasBeenPwnd(hash, setOfPwds) {
+  // format of the set of passwords is
+  // hash:N, hash is a substring of original hash
+  // and N is number of times this pwd has been breached
+  const hashEndingSubstring = hash.substring(5, hash.length);
+  const compromisedPwds = setOfPwds.filter(h => h.split(':')[0] === hashEndingSubstring);
+  return compromisedPwds.length > 0;
+}
+
+/**
+ * Function that handles api query and data formatting
+ * @param {String} hash - SHA-1 hash HEX representation of user passed input
+ * returns Array of HEX to be checked. I
+ */
+function queryHIBP(hash) {
+  const first5chars = hash.substring(0, 5);
+  return fetch(`https://api.pwnedpasswords.com/range/${first5chars}`)
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error('Network response error');
+      }
+      return response.text();
+    }).then(text => text.split('\r\n'));
+}
+
+/**
+ * Function that converts message/text to SHA-1 UTF encoded HEX string
+ * Taken from here: https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest
+ * @param {String} message
+ * Returns capitalized SHA-1 hash HEX representation of user passed input
+ */
+async function digestMessage(message) {
+  //
+  const msgUint8 = new TextEncoder().encode(message);
+  const hashBuffer = await crypto.subtle.digest('SHA-1', msgUint8);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+  return hashHex.toUpperCase();
+}

--- a/src/stories/HdInputPassword.stories.js
+++ b/src/stories/HdInputPassword.stories.js
@@ -26,4 +26,29 @@ storiesOf('Components|Form/HdInputPassword', module)
         action('input')(value);
       },
     },
-  }));
+  }))
+  .add('with hibp check 🎛', () => ({
+    components: { HdInputPassword },
+    template: `
+      <div>
+        <HdInputPassword
+          name="hibp"
+          ref="password"
+          v-model="password"
+        />
+        <button class="btn btn--primary" @click="check">Check Pwnd</button>
+        <p style="margin-top: 8px">Is pwnd: {{ valid }}</p>
+      </div>
+    `,
+    methods: {
+      async check() {
+        this.valid = await this.$refs.password.hasPasswordBeenPwnd();
+      },
+    },
+    data() {
+      return {
+        password: '',
+        valid: false,
+      };
+    },
+  }), { percy: { skip: true } });

--- a/src/stories/HdPasswordConfirm.stories.js
+++ b/src/stories/HdPasswordConfirm.stories.js
@@ -102,4 +102,35 @@ storiesOf('Components|Form/HdPasswordConfirm', module)
         default: text('icon', icon),
       },
     },
-  }));
+  }))
+  .add('with hibp check 🎛', () => ({
+    components: { HdPasswordConfirm },
+    props: {
+      min: {
+        type: Number,
+        default: number('min', 5),
+      },
+    },
+    template: `
+      <div>
+        <hd-password-confirm
+          ref="password"
+          v-model="password"
+          :min="min"
+        />
+        <button class="btn btn--primary" @click="check">Check Pwnd</button>
+        <p style="margin-top: 8px">Is pwnd: {{ valid }}</p>
+      </div>
+    `,
+    methods: {
+      async check() {
+        this.valid = await this.$refs.password.hasPasswordBeenPwnd();
+      },
+    },
+    data() {
+      return {
+        password: '',
+        valid: false,
+      };
+    },
+  }), { percy: { skip: true } });


### PR DESCRIPTION
Jira context: https://homeday.atlassian.net/browse/FET-165

This is a feature proposition, that integrates Have I been pawned (HIPB) API to our HdInputPassword (https://haveibeenpwned.com/API/v3#PwnedPasswords). 

The reason behind this is to minimize the risks of users reusing passwords cross services that have been compromised before, which could lead to unnecessary concerns for us. 

This PR includes: 

1) Service that handles HIPB logic and flow
2) Extends `HdInputPassword` to allow initiating the check for "pawndness"
3) Extends `HdPasswordConfirm` to allow initiating the check for "pawndness"

It's worth noting, that is implementation intention is to minimize the possibility of blocking the flow, while still allowing us to use those checks. 

I'd like to open a discussion: 

1) What do you think about it? 
2) Potential pitfalls I've overlooked 
3) Code review/feedback 
4) Does it make sense to integrate it in above mentioned components? 
4) How to integrate it in a flow, without freaking out the users (e.g.: error messages as "You can't use this password, it has been hacked before" - that could freak out the user :) )?
5) Anything else that comes to mind. :) 

Also, no rush with that, I just wanted to open up a discussion and give initial version of implementation. If we're onboard with it, this might be topic for our FE desing sync, to discuss UX of integration. 

TODO: 
- [ ] Discuss if it makes sense
- [ ] Document the service
- [ ] Extend tests (to what makes sense)

I think this is all in scope of the PR, but let's start with the discussion. :) 

To test it locally, you'll find to added stories in affected components. 