### PR TITLE
[T] Allow HdRange labels to be <html>

### DIFF
--- a/src/components/form/HdRange.vue
+++ b/src/components/form/HdRange.vue
@@ -41,7 +41,7 @@
         <p
           v-if="labels[stepIndex]"
           class="range__step-label"
-          v-text="labels[stepIndex]"
+          v-html="labels[stepIndex]"
         />
       </button>
     </div>

--- a/tests/unit/components/form/HdRange.spec.js
+++ b/tests/unit/components/form/HdRange.spec.js
@@ -133,7 +133,7 @@ describe('HdRange', () => {
   });
 
   describe('Labels', () => {
-    const TEST_LABELS = ['label1', 'label2', 'label3', 'label4'];
+    const TEST_LABELS = ['label1', 'label<br>2', 'label3', 'label4'];
     const TEST_INDEX = Math.round(TEST_LABELS.length / 2);
     const labelsWrapperBuilder = wrapperFactoryBuilder(HdRange, {
       props: {
@@ -145,6 +145,12 @@ describe('HdRange', () => {
         displayStepBullets: true,
         labels: TEST_LABELS,
       },
+    });
+
+    it('renders', () => {
+      const wrapper = labelsWrapperBuilder();
+
+      expect(wrapper.html()).toMatchSnapshot();
     });
 
     it('renders the right number of labels', () => {

--- a/tests/unit/components/form/__snapshots__/HdRange.spec.js.snap
+++ b/tests/unit/components/form/__snapshots__/HdRange.spec.js.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`HdRange Labels renders 1`] = `
+<div class="range field"><input type="range" id="testrange" name="testrange" min="-100" max="100" step="50">
+  <div class="range__track">
+    <div class="range__progress" style="transform: scaleX(0.5);"></div>
+  </div>
+  <div class="range__steps"><button type="button" class="range__step">
+      <p class="range__step-label">label1</p>
+    </button><button type="button" class="range__step">
+      <p class="range__step-label">label<br>2</p>
+    </button><button type="button" class="range__step">
+      <p class="range__step-label">label3</p>
+    </button><button type="button" class="range__step">
+      <p class="range__step-label">label4</p>
+    </button><button type="button" class="range__step">
+      <!----></button></div>
+  <div class="range__thumb" style="transform: translateX(0px);">
+    <!---->
+    <div class="range__thumb__inner">
+      <div class="range__thumb__bullet"></div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`HdRange renders as expected 1`] = `
 <div class="range field"><input type="range" id="testRange" name="testRange" min="-100" max="100" step="50">
   <div class="range__track">


### PR DESCRIPTION
As a background: we need it in our squad as the labels should be side by side but actually break into specific parts of the word and not randomly.

From the tests, that is the scenario **before** this PR once an `<html>` tag was used:
![image](https://user-images.githubusercontent.com/1734873/80521078-b3028380-898a-11ea-8868-eeb8090741e9.png)

Now it will look like expected:
![image](https://user-images.githubusercontent.com/1734873/80521126-c4e42680-898a-11ea-9741-e2bbe4e79659.png)

I don't think we need to add or update anything in the stories. Let me know if you think we should update something there.

Another question: Shall we do the same for the [tooltip value](https://github.com/homeday-de/homeday-blocks/blob/develop/src/components/form/HdRange.vue#L53)?