### PR TITLE
[B] Media Gallery Bug on the Expose Pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15075,14 +15075,6 @@
       "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
       "dev": true
     },
-    "imagesloaded": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/imagesloaded/-/imagesloaded-4.1.4.tgz",
-      "integrity": "sha512-ltiBVcYpc/TYTF5nolkMNsnREHW+ICvfQ3Yla2Sgr71YFwQ86bDwV9hgpFhFtrGPuwEx5+LqOHIrdXBdoWwwsA==",
-      "requires": {
-        "ev-emitter": "^1.0.0"
-      }
-    },
     "immer": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/immer/-/immer-1.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   },
   "dependencies": {
     "body-scroll-lock": "2.6.4",
-    "imagesloaded": "4.1.4",
     "lodash": "4.17.15",
     "natural-scroll": "0.2.2",
     "vue": "2.6.11",

--- a/src/components/gallery/HdGalleryMedia.vue
+++ b/src/components/gallery/HdGalleryMedia.vue
@@ -9,14 +9,10 @@
       <!-- IE11 uses this value only because do not support the picture element -->
       <picture class="gallery-media__object__picture">
         <source v-for="(source, media) in item.pictureSources"
-          :key="media"
-          :media="`(${media})`" :srcset="source"
+                :key="media"
+                :media="`(${media})`" :srcset="source"
         >
-        <img ref="imageHolder"
-             :src="item.image"
-             :alt="item.caption"
-             :srcset="item.imageSrcSet"
-             @load="hideThumbnail"/>
+        <img ref="imageHolder" :src="item.image" :alt="item.caption" :srcset="item.imageSrcSet" @load="hideThumbnail"/>
       </picture>
 
       <div
@@ -34,7 +30,6 @@
 </template>
 
 <script>
-
 export default {
   name: 'HdGalleryMedia',
   props: {
@@ -65,13 +60,9 @@ export default {
   watch: {
     item() {
       this.$nextTick(() => {
-        this.hideThumbnail();
         this.showThumbnail = true;
       });
     },
-  },
-  mounted() {
-    this.hideThumbnail();
   },
   methods: {
     hideThumbnail() {
@@ -82,60 +73,60 @@ export default {
 </script>
 
 <style lang="scss">
-@import 'homeday-blocks/src/styles/mixins.scss';
+  @import 'homeday-blocks/src/styles/mixins.scss';
 
-.gallery-media {
-  $_root: &;
+  .gallery-media {
+    $_root: &;
 
-  &__object {
-    position: relative;
-    overflow: hidden;
-    border-radius: 2px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background-color: $secondary-bg;
-
-    &__thumbnail,
-    &__picture {
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-    }
-
-    &__picture {
+    &__object {
+      position: relative;
+      overflow: hidden;
+      border-radius: 2px;
       display: flex;
       align-items: center;
       justify-content: center;
-    }
+      background-color: $secondary-bg;
 
-    &__thumbnail {
-      background-position: center;
-      background-repeat: no-repeat;
-      background-size: contain;
-      @media (min-width: $break-tablet) {
-        background-size: cover;
+      &__thumbnail,
+      &__picture {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
       }
-    }
 
-    img {
-      max-width: 100%;
-      max-height: 100%;
-    }
+      &__picture {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
 
-    &__thumbnail {
-      opacity: 0;
-      transition: opacity ($time-s * 2) ease-in-out, transform .2s;
-      filter: blur(4px);
+      &__thumbnail {
+        background-position: center;
+        background-repeat: no-repeat;
+        background-size: contain;
+        @media (min-width: $break-tablet) {
+          background-size: cover;
+        }
+      }
 
-      &.isVisible {
-        opacity: 1;
-        transition: none;
-        transform: scale(1.03);
+      img {
+        max-width: 100%;
+        max-height: 100%;
+      }
+
+      &__thumbnail {
+        opacity: 0;
+        transition: opacity ($time-s * 2) ease-in-out, transform .2s;
+        filter: blur(4px);
+
+        &.isVisible {
+          opacity: 1;
+          transition: none;
+          transform: scale(1.03);
+        }
       }
     }
   }
-}
 </style>

--- a/src/components/gallery/HdGalleryMedia.vue
+++ b/src/components/gallery/HdGalleryMedia.vue
@@ -73,60 +73,60 @@ export default {
 </script>
 
 <style lang="scss">
-  @import 'homeday-blocks/src/styles/mixins.scss';
+@import 'homeday-blocks/src/styles/mixins.scss';
 
-  .gallery-media {
-    $_root: &;
+.gallery-media {
+  $_root: &;
 
-    &__object {
-      position: relative;
-      overflow: hidden;
-      border-radius: 2px;
+  &__object {
+    position: relative;
+    overflow: hidden;
+    border-radius: 2px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: $secondary-bg;
+
+    &__thumbnail,
+    &__picture {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+    }
+
+    &__picture {
       display: flex;
       align-items: center;
       justify-content: center;
-      background-color: $secondary-bg;
+    }
 
-      &__thumbnail,
-      &__picture {
-        position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
+    &__thumbnail {
+      background-position: center;
+      background-repeat: no-repeat;
+      background-size: contain;
+      @media (min-width: $break-tablet) {
+        background-size: cover;
       }
+    }
 
-      &__picture {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-      }
+    img {
+      max-width: 100%;
+      max-height: 100%;
+    }
 
-      &__thumbnail {
-        background-position: center;
-        background-repeat: no-repeat;
-        background-size: contain;
-        @media (min-width: $break-tablet) {
-          background-size: cover;
-        }
-      }
+    &__thumbnail {
+      opacity: 0;
+      transition: opacity ($time-s * 2) ease-in-out, transform .2s;
+      filter: blur(4px);
 
-      img {
-        max-width: 100%;
-        max-height: 100%;
-      }
-
-      &__thumbnail {
-        opacity: 0;
-        transition: opacity ($time-s * 2) ease-in-out, transform .2s;
-        filter: blur(4px);
-
-        &.isVisible {
-          opacity: 1;
-          transition: none;
-          transform: scale(1.03);
-        }
+      &.isVisible {
+        opacity: 1;
+        transition: none;
+        transform: scale(1.03);
       }
     }
   }
+}
 </style>

--- a/src/components/gallery/HdGalleryMedia.vue
+++ b/src/components/gallery/HdGalleryMedia.vue
@@ -30,7 +30,6 @@
 </template>
 
 <script>
-import imagesLoaded from 'imagesloaded';
 
 export default {
   name: 'HdGalleryMedia',
@@ -75,9 +74,16 @@ export default {
       this.showThumbnail = false;
     },
     hideThumbnailOnBgLoad() {
-      imagesLoaded(this.$refs.imageHolder, () => {
-        this.showThumbnail = false;
-      });
+      const self = this;
+      if (self.$refs.imageHolder) {
+        const checkImage = setInterval(() => {
+          const isImageOk = self.$refs.imageHolder.complete;
+          if (isImageOk) {
+            clearInterval(checkImage);
+            self.showThumbnail = false;
+          }
+        }, 1);
+      }
     },
   },
 };
@@ -129,12 +135,13 @@ export default {
 
     &__thumbnail {
       opacity: 0;
-      transition: opacity ($time-s * 2) ease-in-out;
+      transition: opacity ($time-s * 2) ease-in-out, transform .2s;
       filter: blur(4px);
 
       &.isVisible {
         opacity: 1;
         transition: none;
+        transform: scale(1.03);
       }
     }
   }

--- a/src/components/gallery/HdGalleryMedia.vue
+++ b/src/components/gallery/HdGalleryMedia.vue
@@ -74,15 +74,13 @@ export default {
       this.showThumbnail = false;
     },
     hideThumbnailOnBgLoad() {
-      const self = this;
-      if (self.$refs.imageHolder) {
-        const checkImage = setInterval(() => {
-          const isImageOk = self.$refs.imageHolder.complete;
+      if (this.$refs.imageHolder) {
+        this.$refs.imageHolder.addEventListener('load', () => {
+          const isImageOk = this.$refs.imageHolder.complete;
           if (isImageOk) {
-            clearInterval(checkImage);
-            self.showThumbnail = false;
+            this.showThumbnail = false;
           }
-        }, 1);
+        });
       }
     },
   },

--- a/src/components/gallery/HdGalleryMedia.vue
+++ b/src/components/gallery/HdGalleryMedia.vue
@@ -12,7 +12,11 @@
           :key="media"
           :media="`(${media})`" :srcset="source"
         >
-        <img ref="imageHolder" :src="item.image" :alt="item.caption" :srcset="item.imageSrcSet"/>
+        <img ref="imageHolder"
+             :src="item.image"
+             :alt="item.caption"
+             :srcset="item.imageSrcSet"
+             @load="hideThumbnail"/>
       </picture>
 
       <div
@@ -61,27 +65,17 @@ export default {
   watch: {
     item() {
       this.$nextTick(() => {
-        this.hideThumbnailOnBgLoad();
+        this.hideThumbnail();
         this.showThumbnail = true;
       });
     },
   },
   mounted() {
-    this.hideThumbnailOnBgLoad();
+    this.hideThumbnail();
   },
   methods: {
-    imageLoadListener() {
+    hideThumbnail() {
       this.showThumbnail = false;
-    },
-    hideThumbnailOnBgLoad() {
-      if (this.$refs.imageHolder) {
-        this.$refs.imageHolder.addEventListener('load', () => {
-          const isImageOk = this.$refs.imageHolder.complete;
-          if (isImageOk) {
-            this.showThumbnail = false;
-          }
-        });
-      }
     },
   },
 };


### PR DESCRIPTION
Hi Guys,

We were living a problem with the HD Gallery Media component on the expose pages. The problem was about image loaded function. The image's loaded function was working without loaded (https://youtu.be/dEJPW-9Lo8k). So, the function wasn't working properly, for this reason, I checked the 'imagesLoaded' dependency and the code does a couple of different controls for image load statements.

1. img's `naturalWidth` check:
https://github.com/desandro/imagesloaded/blob/master/imagesloaded.js#L270
2. `load` and `error` events:
https://github.com/desandro/imagesloaded/blob/master/imagesloaded.js#L276
3. `.complete` property control:
https://github.com/desandro/imagesloaded/blob/master/imagesloaded.js#L287

I had doubts that the `.complete` property of the image is not working. There is an example that people face the same issue: https://github.com/desandro/imagesloaded/issues/241

After I read that, I focused that remove that dependency from our HD-blocks: https://github.com/desandro/imagesloaded/issues/270#issuecomment-438176861
Our problem was exactly like that (at the same time you can see what was our problem on the screen): https://youtu.be/dEJPW-9Lo8k  

I developed `hideThumbnailOnBgLoad()` function for this case, I removed the 'imagesLoaded' dependency and used `.complete` property for check the image load statement.

`hideThumbnailOnBgLoad()` function starts when the user clicks the next image button, The function is creates a `setInterval()` function and checks image each 1ms until `image.complete` return true. In that way, we can hide/show thumbnail when image.complete is true.

This javascript's `.complete` property supports by all browsers. (https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/complete) - I did tests after these changes on my localhost, you can see the video on here: https://youtu.be/XoNyQc0gw2s

![giphy](https://user-images.githubusercontent.com/14016028/80868488-38dc4280-8c9b-11ea-8bd7-59ddfc69d570.gif)
