### PR TITLE
[B] Fix the IE11 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24596,9 +24596,9 @@
       "dev": true
     },
     "vue-inline-svg": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/vue-inline-svg/-/vue-inline-svg-1.2.0.tgz",
-      "integrity": "sha512-a+tu6ECRvCih0BeLULTuXu54k6UaQEUOAMni84PN+Hhz3nKHwGcMReIL1Ya5n2TA9qYJ4xxvtdRLpQwzQqGFTQ=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/vue-inline-svg/-/vue-inline-svg-1.3.1.tgz",
+      "integrity": "sha512-kEroJGlxWR8Plm2H0s3DaNcMYrBFaJvcB7OwWBaeo18KbbrA9aik1ztSGDGXg+e7mQaeh2u1jJnABPVuKHVNhg=="
     },
     "vue-jest": {
       "version": "3.0.5",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "natural-scroll": "0.2.2",
     "vue": "2.6.11",
     "vue-flickity": "1.2.1",
-    "vue-inline-svg": "1.2.0",
+    "vue-inline-svg": "1.3.1",
     "vue-zoomer": "homeday-de/vue-zoomer#0.5.0"
   },
   "devDependencies": {

--- a/src/components/HdIcon.vue
+++ b/src/components/HdIcon.vue
@@ -8,7 +8,7 @@
 
 <script>
 import _intersection from 'lodash/intersection';
-import InlineSvg from 'vue-inline-svg/dist/vue-inline-svg';
+import InlineSvg from 'vue-inline-svg';
 
 export default {
   name: 'HdIcon',

--- a/src/components/HdIcon.vue
+++ b/src/components/HdIcon.vue
@@ -8,7 +8,7 @@
 
 <script>
 import _intersection from 'lodash/intersection';
-import InlineSvg from 'vue-inline-svg';
+import InlineSvg from 'vue-inline-svg/dist/vue-inline-svg';
 
 export default {
   name: 'HdIcon',

--- a/src/stories/Welcome.vue
+++ b/src/stories/Welcome.vue
@@ -3,27 +3,35 @@
     <h1 class="welcome__title">Homeday-Blocks</h1>
     <p class="welcome__paragraph">A Vue component library built by Homeday's frontend team.</p>
 
-    <h3 class="welcome__subtitle">Start using the library in 3 quick steps</h3>
+    <h3 class="welcome__subtitle">Start using the library in 2 quick steps</h3>
     <p class="welcome__paragraph">
       1- Install the library:
       <vue-code-highlight class="welcome__code">{{
-        `npm install homeday-de/homeday-blocks --save`
+        "npm install homeday-de/homeday-blocks --save"
       }}</vue-code-highlight>
       2- Consume the components
       <vue-code-highlight class="welcome__code">{{
-        'import { HdGallery } from \'homeday-blocks\';'
+        "import { HdGallery } from 'homeday-blocks';"
       }}</vue-code-highlight>
     </p>
 
+    <h3 class="welcome__subtitle">Older browsers support</h3>
+    <p class="welcome__paragraph">
+      As we are serving "raw" components, and babel-loader doesn't transpile the dependencies by default,
+      you might want to ask it to do so.<br />
+      Our recommended solution is to use transpileDependencies in the Vue config file:
+      <vue-code-highlight class="welcome__code">{{
+        "transpileDependencies: ['homeday-blocks', 'vue-zoomer'],"
+      }}</vue-code-highlight>
+    </p>
     <h3 class="welcome__subtitle">How to use our storybook?</h3>
-    <div class="welcome__paragraph">
-      <h4>You don't have to check all the tabs to see if something is available. We use some suffixes in the story's title:</h4>
-      <div class="text-small margin-top-s margin-left-m">
-        <p>🎛 : Check the knobs tab to play around with the component's props</p>
-        <p>📝 : Check the notes tab for more information about the component, how to use it or code snippets</p>
-      </div>
-    </div>
-
+    <h4>You don't have to check all the tabs to see if something is available. We use some suffixes in the story's title:</h4>
+    <p class="welcome__paragraph">
+      <ul class="text-small margin-top-s margin-left-m">
+        <li>🎛 : Check the knobs tab to play around with the component's props</li>
+        <li>📝 : Check the notes tab for more information about the component, how to use it or code snippets</li>
+      </ul>
+    </p>
     <h3 class="welcome__subtitle">Contributing :)</h3>
     <p class="welcome__paragraph">Check out our <a class="link" href="https://github.com/homeday-de/homeday-blocks">Github repository</a> for more details.</p>
   </div>

--- a/src/stories/Welcome.vue
+++ b/src/stories/Welcome.vue
@@ -19,7 +19,9 @@
     <p class="welcome__paragraph">
       As we are serving "raw" components, and babel-loader doesn't transpile the dependencies by default,
       you might want to ask it to do so.<br />
-      Our recommended solution is to use transpileDependencies in the Vue config file:
+      Our recommended solution is to use
+      <a class="link" href="https://cli.vuejs.org/config/#transpiledependencies" target="_blank">transpileDependencies</a>
+      in the Vue config file:
       <vue-code-highlight class="welcome__code">{{
         "transpileDependencies: ['homeday-blocks', 'vue-zoomer'],"
       }}</vue-code-highlight>
@@ -33,7 +35,8 @@
       </ul>
     </p>
     <h3 class="welcome__subtitle">Contributing :)</h3>
-    <p class="welcome__paragraph">Check out our <a class="link" href="https://github.com/homeday-de/homeday-blocks">Github repository</a> for more details.</p>
+    <p class="welcome__paragraph">
+      Check out our <a class="link" href="https://github.com/homeday-de/homeday-blocks" target="_blank">Github repository</a> for more details.</p>
   </div>
 </template>
 


### PR DESCRIPTION
The `vue-inline-svg` points to an uncomplied file in its package.json (the `module` property).
So I changed the import path to pick the compiled file. This is not ideal, because we depend on the location of the file (I made sure that we use an exact version), I'm planning to open an issue (or a PR) in their repo, so we can hand this better.

I've also updated the welcome page.