### PR TITLE
[F] RadioButton improvements

### DIFF
--- a/src/components/buttons/HdRadioButton.vue
+++ b/src/components/buttons/HdRadioButton.vue
@@ -32,7 +32,7 @@
         class="radioButton__icon"
       />
     </div>
-    <label :for="name" class="radioButton__label" v-text="label" />
+    <label :for="name" class="radioButton__label" v-html="label" />
     <HdIcon
       :src="chevronIcon"
       class="radioButton__chevron"

--- a/src/components/buttons/HdRadioButton.vue
+++ b/src/components/buttons/HdRadioButton.vue
@@ -52,7 +52,7 @@ export default {
   props: {
     label: String,
     value: {
-      type: [String, Number],
+      type: [String, Number, Object],
       required: true,
     },
     name: {

--- a/tests/unit/components/notifications/HdNotifications.spec.js
+++ b/tests/unit/components/notifications/HdNotifications.spec.js
@@ -36,15 +36,15 @@ describe('HdNotifications', () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it('fires the heightChange event when height of the notifications changes', async () => {
-    // A random number, used just to make sure it's not 0 and that the height actually changes
-    const mockedScrollHeight = jest.fn(() => 123);
+  // it('fires the heightChange event when height of the notifications changes', async () => {
+  //   // A random number, used just to make sure it's not 0 and that the height actually changes
+  //   const mockedScrollHeight = jest.fn(() => 123);
 
-    wrapper.setMethods({ getScrollHeight: mockedScrollHeight });
-    wrapper.setProps({ notifications: NOTIFICATIONS.slice(-1) });
+  //   wrapper.setMethods({ getScrollHeight: mockedScrollHeight });
+  //   wrapper.setProps({ notifications: NOTIFICATIONS.slice(-1) });
 
-    await wrapper.vm.$nextTick();
+  //   await wrapper.vm.$nextTick();
 
-    expect(wrapper.emitted('heightChange')).toBeTruthy();
-  });
+  //   expect(wrapper.emitted('heightChange')).toBeTruthy();
+  // });
 });

--- a/tests/unit/components/notifications/HdNotifications.spec.js
+++ b/tests/unit/components/notifications/HdNotifications.spec.js
@@ -44,7 +44,6 @@ describe('HdNotifications', () => {
     wrapper.setProps({ notifications: NOTIFICATIONS.slice(-1) });
 
     await wrapper.vm.$nextTick();
-    await wrapper.vm.$nextTick();
 
     expect(wrapper.emitted('heightChange')).toBeTruthy();
   });

--- a/tests/unit/components/notifications/HdNotifications.spec.js
+++ b/tests/unit/components/notifications/HdNotifications.spec.js
@@ -36,15 +36,16 @@ describe('HdNotifications', () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  // it('fires the heightChange event when height of the notifications changes', async () => {
-  //   // A random number, used just to make sure it's not 0 and that the height actually changes
-  //   const mockedScrollHeight = jest.fn(() => 123);
+  it('fires the heightChange event when height of the notifications changes', async () => {
+    // A random number, used just to make sure it's not 0 and that the height actually changes
+    const mockedScrollHeight = jest.fn(() => 123);
 
-  //   wrapper.setMethods({ getScrollHeight: mockedScrollHeight });
-  //   wrapper.setProps({ notifications: NOTIFICATIONS.slice(-1) });
+    wrapper.setMethods({ getScrollHeight: mockedScrollHeight });
+    wrapper.setProps({ notifications: NOTIFICATIONS.slice(-1) });
 
-  //   await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
 
-  //   expect(wrapper.emitted('heightChange')).toBeTruthy();
-  // });
+    expect(wrapper.emitted('heightChange')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
Changed the label to render html so we can add spans and customize the text.
Changed type to accept objects. That could be the case depending on the project (we have a case like that on sliders).
And the unit test was failing... not sure why, couldn't find any changes related to it...
for some reason the first $nextTick() didn't digest the event all the way before the assert. 