### PR TITLE
[F] validate only non-empty input value

### DIFF
--- a/src/components/form/HdInput.vue
+++ b/src/components/form/HdInput.vue
@@ -194,6 +194,8 @@ export default {
     showError(errorMessage) {
       this.error = errorMessage;
       this.isValid = false;
+
+      return false;
     },
     showHelper(message) {
       this.helper = message;
@@ -201,33 +203,38 @@ export default {
     hideError() {
       this.isValid = true;
       this.error = null;
+
+      return true;
     },
     validate() {
       if (this.required && this.isEmpty) {
-        this.showError(this.t.FORM.VALIDATION.REQUIRED);
-      } else if (!this.isEmpty) {
-        if (this.currentType === 'email' && !validateEmail(this.value)) {
-          this.showError(this.t.FORM.VALIDATION.INVALID_EMAIL);
-        } else if (this.currentType === 'date' && !validateDate(this.value)) {
-          this.showError(this.t.FORM.VALIDATION.INVALID_DATE);
-        } else if (this.customRules.length) {
-          this.validateCustomRules();
-        } else {
-          this.hideError();
-        }
-      } else {
-        this.hideError();
+        return this.showError(this.t.FORM.VALIDATION.REQUIRED);
       }
 
-      return !this.error;
+      if (!this.isEmpty) {
+        if (this.currentType === 'email' && !validateEmail(this.value)) {
+          return this.showError(this.t.FORM.VALIDATION.INVALID_EMAIL);
+        }
+
+        if (this.currentType === 'date' && !validateDate(this.value)) {
+          return this.showError(this.t.FORM.VALIDATION.INVALID_DATE);
+        }
+
+        if (this.customRules.length) {
+          return this.validateCustomRules();
+        }
+      }
+
+      return this.hideError();
     },
     validateCustomRules() {
       const firstFailingRule = this.customRules.find(({ validate }) => !validate(this.value));
+
       if (firstFailingRule) {
-        this.showError(firstFailingRule.errorMessage);
-      } else {
-        this.hideError();
+        return this.showError(firstFailingRule.errorMessage);
       }
+
+      return this.hideError();
     },
   },
 };

--- a/src/components/form/HdInput.vue
+++ b/src/components/form/HdInput.vue
@@ -205,12 +205,16 @@ export default {
     validate() {
       if (this.required && this.isEmpty) {
         this.showError(this.t.FORM.VALIDATION.REQUIRED);
-      } else if (this.currentType === 'email' && !validateEmail(this.value)) {
-        this.showError(this.t.FORM.VALIDATION.INVALID_EMAIL);
-      } else if (this.currentType === 'date' && !validateDate(this.value)) {
-        this.showError(this.t.FORM.VALIDATION.INVALID_DATE);
-      } else if (this.customRules.length && !this.isEmpty) {
-        this.validateCustomRules();
+      } else if (!this.isEmpty) {
+        if (this.currentType === 'email' && !validateEmail(this.value)) {
+          this.showError(this.t.FORM.VALIDATION.INVALID_EMAIL);
+        } else if (this.currentType === 'date' && !validateDate(this.value)) {
+          this.showError(this.t.FORM.VALIDATION.INVALID_DATE);
+        } else if (this.customRules.length) {
+          this.validateCustomRules();
+        } else {
+          this.hideError();
+        }
       } else {
         this.hideError();
       }

--- a/tests/unit/components/form/HdInput.spec.js
+++ b/tests/unit/components/form/HdInput.spec.js
@@ -105,11 +105,11 @@ describe('HdInput', () => {
     it('validates email', async () => {
       const VALID_EMAIL = 'valid@email.com';
       const INVALID_EMAIL = 'unvalid@email@com';
-      const wrapper = emailWrapperBuilder({
-        props: {
-          value: INVALID_EMAIL,
-        },
-      });
+      const wrapper = emailWrapperBuilder();
+
+      expect(wrapper.vm.validate()).toBe(true);
+
+      wrapper.setProps({ value: INVALID_EMAIL });
 
       expect(wrapper.vm.validate()).toBe(false);
 
@@ -143,11 +143,11 @@ describe('HdInput', () => {
     it('validates date', async () => {
       const VALID_DATE = '1990-01-01';
       const INVALID_DATE = '01-01-1990';
-      const wrapper = dateWrapperBuilder({
-        props: {
-          value: INVALID_DATE,
-        },
-      });
+      const wrapper = dateWrapperBuilder();
+
+      expect(wrapper.vm.validate()).toBe(true);
+
+      wrapper.setProps({ value: INVALID_DATE });
 
       expect(wrapper.vm.validate()).toBe(false);
 


### PR DESCRIPTION
Thread: https://homeday.slack.com/archives/C41SHFS5R/p1591690652006900

---

Right now if an input is empty (and not required) it is still validated.

See the GIF below:
- Empty state is not validate first ✅
- Invalid e-mail is validated and error message is shown ✅
- Valid e-mail is validated and error message is removed ✅
- Empty state is validated and error message is shown ❌
![Example](https://user-images.githubusercontent.com/1734873/84636314-bfb84800-aef4-11ea-8a39-c6d59c7724fd.gif)

The new behavior will validate empty inputs only if they're required, otherwise the validation method is not called.