### PR TITLE
[F] Browser autofill behavior

### DIFF
--- a/src/styles/inputs.scss
+++ b/src/styles/inputs.scss
@@ -6,6 +6,12 @@ $inputBackground: $secondary-bg;
 $inputPaddingTop: $labelHeight + $stack-xs;
 $focusedLabelTop: 5px;
 
+@mixin filledState {
+  font-size: 14px;
+  line-height: 18px;
+  top: $focusedLabelTop;
+}
+
 .field {
   $f: &;
   position: relative;
@@ -127,9 +133,7 @@ $focusedLabelTop: 5px;
     pointer-events: none;
 
     #{$f}--filled &, #{$f}--active &, #{$f}--select &, #{$f}--double & {
-      font-size: 14px;
-      line-height: 18px;
-      top: $focusedLabelTop;
+      @include filledState;
     }
 
     #{$f}--active & {
@@ -338,6 +342,10 @@ $focusedLabelTop: 5px;
     &::placeholder {
       color: getShade($quaternary-color, 80);
       opacity: 0.5;
+    }
+
+    &:-webkit-autofill + #{$f}__label {
+      @include filledState;
     }
   }
 

--- a/src/styles/inputs.scss
+++ b/src/styles/inputs.scss
@@ -6,12 +6,6 @@ $inputBackground: $secondary-bg;
 $inputPaddingTop: $labelHeight + $stack-xs;
 $focusedLabelTop: 5px;
 
-@mixin filledState {
-  font-size: 14px;
-  line-height: 18px;
-  top: $focusedLabelTop;
-}
-
 .field {
   $f: &;
   position: relative;
@@ -132,8 +126,10 @@ $focusedLabelTop: 5px;
     z-index: 9;
     pointer-events: none;
 
-    #{$f}--filled &, #{$f}--active &, #{$f}--select &, #{$f}--double & {
-      @include filledState;
+    #{$f}--filled &, #{$f}--active &, #{$f}--select &, #{$f}--double &, #{$f}__input:-webkit-autofill + & {
+      font-size: 14px;
+      line-height: 18px;
+      top: $focusedLabelTop;
     }
 
     #{$f}--active & {
@@ -342,10 +338,6 @@ $focusedLabelTop: 5px;
     &::placeholder {
       color: getShade($quaternary-color, 80);
       opacity: 0.5;
-    }
-
-    &:-webkit-autofill + #{$f}__label {
-      @include filledState;
     }
   }
 


### PR DESCRIPTION
I've decided to keep the `mixin` inside the `input.scss` file as it won't be used anywhere else.

I've done some research here and decided to implement the same as the official library (https://github.com/material-components/material-components-web/blob/b9776b1d09b9ccfac38b3dc471dee2fd9fc8558a/packages/mdc-textfield/_mixins.scss#L108)

You can read about another approach here: https://github.com/mui-org/material-ui/issues/14427 --> I've also tried it but it just adds complexity for us.