### PR TITLE
[B] Validate the original value of HdInputFormatter

### DIFF
--- a/src/components/form/HdInput.vue
+++ b/src/components/form/HdInput.vue
@@ -206,29 +206,29 @@ export default {
 
       return true;
     },
-    validate() {
+    validate(value = this.value) {
       if (this.required && this.isEmpty) {
         return this.showError(this.t.FORM.VALIDATION.REQUIRED);
       }
 
       if (!this.isEmpty) {
-        if (this.currentType === 'email' && !validateEmail(this.value)) {
+        if (this.currentType === 'email' && !validateEmail(value)) {
           return this.showError(this.t.FORM.VALIDATION.INVALID_EMAIL);
         }
 
-        if (this.currentType === 'date' && !validateDate(this.value)) {
+        if (this.currentType === 'date' && !validateDate(value)) {
           return this.showError(this.t.FORM.VALIDATION.INVALID_DATE);
         }
 
         if (this.customRules.length) {
-          return this.validateCustomRules();
+          return this.validateCustomRules(value);
         }
       }
 
       return this.hideError();
     },
-    validateCustomRules() {
-      const firstFailingRule = this.customRules.find(({ validate }) => !validate(this.value));
+    validateCustomRules(value = this.value) {
+      const firstFailingRule = this.customRules.find(({ validate }) => !validate(value));
 
       if (firstFailingRule) {
         return this.showError(firstFailingRule.errorMessage);

--- a/src/components/form/HdInputFormatter.vue
+++ b/src/components/form/HdInputFormatter.vue
@@ -57,10 +57,14 @@ export default {
       this.boundType = this.type;
       this.$emit('focus');
     },
-    handleBlurEvent() {
+    async handleBlurEvent() {
       this.isFocused = false;
       this.boundType = defaultInputType;
       this.$emit('blur');
+
+      await this.$nextTick();
+
+      this.validate();
     },
     handleInputEvent(value) {
       this.$emit('input', value);
@@ -71,8 +75,8 @@ export default {
     showHelper(...args) {
       return this.$refs.input.showHelper(...args);
     },
-    validate(...args) {
-      return this.$refs.input.validate(...args);
+    validate() {
+      return this.$refs.input.validate(this.boundValue);
     },
     hideError(...args) {
       return this.$refs.input.hideError(...args);

--- a/src/stories/HdInputFormatter.stories.js
+++ b/src/stories/HdInputFormatter.stories.js
@@ -5,6 +5,7 @@ import { HdInputFormatter } from 'homeday-blocks';
 import FormWrapper from 'homeday-blocks/src/storiesWrappers/FormWrapper';
 
 storiesOf('Components|Form/HdInputFormatter', module)
+  .addParameters({ percy: { skip: true } })
   .addDecorator(FormWrapper)
   .add('simple', () => ({
     components: { HdInputFormatter },
@@ -36,7 +37,39 @@ storiesOf('Components|Form/HdInputFormatter', module)
         action('input')(value);
       },
     },
-  }), {
-    // Doesn't make sense to test the UI of this components because it's based on HdInput
-    percy: { skip: true },
-  });
+  }))
+  .add('with validation', () => ({
+    components: { HdInputFormatter },
+    template: `
+      <div class="text-xsmall">
+        <p>Try a value lower than 1.000.000</p><br>
+        <HdInputFormatter
+          v-model="value"
+          :formatter="formatter"
+          name="test"
+          label="Currency formatter"
+          type="number"
+          :custom-rules="[rule]"
+        />
+        <p>As you can see, the validation is done on the original value, and not the formatted one
+        (which contain some dots htat make parsing hard)</p>
+      </div>
+    `,
+    data() {
+      return {
+        value: 50,
+        rule: {
+          validate(value) {
+            return value > 1000000;
+          },
+          errorMessage: 'The value should be > 1.000.000',
+        },
+      };
+    },
+    methods: {
+      formatter(value) {
+        return new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' })
+          .format(value);
+      },
+    },
+  }));

--- a/tests/unit/components/form/HdInputFormatter.spec.js
+++ b/tests/unit/components/form/HdInputFormatter.spec.js
@@ -117,4 +117,24 @@ describe('HdInputFormatter', () => {
 
     expect(wrapper.emitted('input')[0][0]).toBe(String(defaultValue));
   });
+
+  it('should validate the raw value', () => {
+    const VALUE = 10;
+    const FORMATTED_VALUE = '100';
+    const wrapper = wrapperBuilder({
+      props: {
+        formatter: () => FORMATTED_VALUE,
+        value: VALUE,
+        customRules: [
+          {
+            validate: value => value < 50,
+            errorMessage: 'error',
+          },
+        ],
+      },
+    });
+
+    expect(wrapper.find('input').element.value).toBe(FORMATTED_VALUE);
+    expect(wrapper.vm.validate()).toBe(true);
+  });
 });


### PR DESCRIPTION
Currently we are validating the value that's being shown in the input, but that shouldn't be the case for HdInputFormatter because we typically want to validate the original value and not the formatted one.

**Example:**
Let's say we want to validate that the value is greater than `1000`, if we have a number formatter (like in the example story), the formatted value will be `"1.000"`, as a string, so our validation won't work because we are comparing a string with a number, that can be solved using parseFloat or similar functions, but parsing `"1.000"` will result in `1` (because of the dot).
This is just an example but don't look at it as the only case.

**Proposed solution**
I'm allowing other components (HdInputFormatter in this case) to use the `validate` method with a desired value (the default is the local `this.value`).
I've also thought of passing a `valueToValidate` prop to HdInput, but I didn't want to mess too much with HdInput's API.


What do you think? Do you have any other suggestions?