### PR TITLE
[B] Allow decimal numbers on webkit browsers

### DIFF
--- a/src/components/form/HdInput.vue
+++ b/src/components/form/HdInput.vue
@@ -178,8 +178,9 @@ export default {
       if (this.currentType === 'number' && newValue !== '') {
         newValue = parseFloat(newValue);
 
-        // If the parse value has no change we don't emit the new value
-        // because it might suppress the the decimals' dot
+        // If the parsed value is the same as the current value
+        // we don't emit the custom input event
+        // because it might suppress the the decimal deparator on webkit browsers
         if (newValue === this.value) {
           return;
         }

--- a/src/components/form/HdInput.vue
+++ b/src/components/form/HdInput.vue
@@ -180,7 +180,7 @@ export default {
 
         // If the parsed value is the same as the current value
         // we don't emit the custom input event
-        // because it might suppress the the decimal deparator on webkit browsers
+        // because it might suppress the the decimal separator on webkit browsers
         if (newValue === this.value) {
           return;
         }

--- a/src/components/form/HdInput.vue
+++ b/src/components/form/HdInput.vue
@@ -178,6 +178,12 @@ export default {
       if (this.currentType === 'number' && newValue !== '') {
         newValue = parseFloat(newValue);
 
+        // If the parse value has no change we don't emit the new value
+        // because it might suppress the the decimals' dot
+        if (newValue === this.value) {
+          return;
+        }
+
         if (typeof this.min === 'number' && newValue < this.min) {
           newValue = this.min;
         } else if (typeof this.max === 'number' && newValue > this.max) {

--- a/src/stories/HdDashedList.stories.js
+++ b/src/stories/HdDashedList.stories.js
@@ -4,7 +4,7 @@ import { boolean } from '@storybook/addon-knobs';
 import { HdDashedList } from 'homeday-blocks';
 import ITEMS from './mocks/DASHED_LIST_ITEMS';
 
-const stories = storiesOf('HdDashedList', module);
+const stories = storiesOf('Components|HdDashedList', module);
 
 stories.add('Playground 🎛', () => ({
   components: { HdDashedList },

--- a/src/stories/HdModal.stories.js
+++ b/src/stories/HdModal.stories.js
@@ -2,7 +2,7 @@
 import { storiesOf } from '@storybook/vue';
 import { HdModal } from 'homeday-blocks';
 
-const stories = storiesOf('HdModal', module);
+const stories = storiesOf('Components|HdModal', module);
 
 stories.add('Default', () => ({
   components: { HdModal },
@@ -57,12 +57,12 @@ stories.add('Light', () => ({
         closeIconColor="light"
         overlayColor="light"
       >
-        <div 
+        <div
         slot="header"
         style="background:#2988ff;"
         >This is the modal header.
         </div>
-        <div 
+        <div
         slot="content"
         >This is the modal content.
         </div>


### PR DESCRIPTION
### The bug
Currently if you try to type a decimal number in an HdInput with type "number" you won't be able to do so on webkit browsers (tested on Safari mobile and desktop and Chrome for iOS).
The reason is that when you type a dot to add  the decimal part, webkit browsers emit an `input` event, which is not the case for the modern browsers (take that 🍎!) and will make use parse the new value, so `123.` will immediately become `123`, so the user won't even see the dot.

### Suggested solution
Before we emit the new value we compare the parsed number if it's the same as the current value, if they are, we don't emit the custom `input` event. This way, the parent won't know about the added dot, but when we add a number after the dot the parsed value will change and that's when we emit the `input` event.
**Example:**
| Input value | Emitted value | Model value |
|-------------|---------------|-------------|
| `"123"`     | `123`         | `123`       |
| `"123."`    | -             | `123`       |
| `"123.4"`   | `123.4`       | `123.4`     |