### PR TITLE
[B] Fix the input label on Firefox

### DIFF
--- a/src/styles/inputs.scss
+++ b/src/styles/inputs.scss
@@ -126,10 +126,20 @@ $focusedLabelTop: 5px;
     z-index: 9;
     pointer-events: none;
 
-    #{$f}--filled &, #{$f}--active &, #{$f}--select &, #{$f}--double &, #{$f}__input:-webkit-autofill + & {
+    @mixin minimized {
       font-size: 14px;
       line-height: 18px;
       top: $focusedLabelTop;
+    }
+
+    #{$f}--filled &, #{$f}--active &, #{$f}--select &, #{$f}--double & {
+      @include minimized;
+    }
+
+    // We are seperating this declaration from the block above
+    // because non-webkit engines will ignore the whole block, e.g. Gecko
+    #{$f}__input:-webkit-autofill + & {
+      @include minimized;
     }
 
     #{$f}--active & {


### PR DESCRIPTION
Caught by Percy :purple_heart:

The previous implementation was translating to:
```scss
.field--active .field__label,
.field--double .field__label,
.field--filled .field__label,
.field--select .field__label,
.field__input:-webkit-autofill+.field__label {
   font-size:14px;
   line-height:18px;
   top:5px
}
```

and Firefox was weirdly ignoring the whole block because of the prefix `-webkit-`, even if they are separated with a comma 🤷‍♂️ 

Which resulted in this:
![image](https://user-images.githubusercontent.com/30146019/85311794-3f768180-b4b6-11ea-87a4-8d1eec0e2c21.png)


##### Always IE11, last time Safari and now Firefox... I love diversity, but not in browsers 😆 or at least, not in the used engines.