### PR TITLE
refactor HdToast unit test

### DIFF
--- a/tests/unit/components/HdToast.spec.js
+++ b/tests/unit/components/HdToast.spec.js
@@ -26,13 +26,9 @@ describe('HdToast', () => {
 
   it("primary <button> calls 'primaryClick' when clicked", () => {
     const text = 'random-text';
-    const primaryClickMock = jest.fn();
     const wrapper = wrapperBuilder({
       props: {
         primaryLabel: text,
-      },
-      methods: {
-        primaryClick: primaryClickMock,
       },
     });
 
@@ -40,7 +36,7 @@ describe('HdToast', () => {
 
     button.trigger('click');
 
-    expect(primaryClickMock).toHaveBeenCalledTimes(1);
+    expect(wrapper.emitted().primaryClick).toBeTruthy();
   });
 
   it("'secondaryLabel' text binds to secondary <button>", () => {
@@ -59,13 +55,9 @@ describe('HdToast', () => {
 
   it("secondary <button> calls 'secondaryClick' when clicked", () => {
     const text = 'random-text';
-    const secondaryClickMock = jest.fn();
     const wrapper = wrapperBuilder({
       props: {
         secondaryLabel: text,
-      },
-      methods: {
-        secondaryClick: secondaryClickMock,
       },
     });
 
@@ -73,7 +65,7 @@ describe('HdToast', () => {
 
     button.trigger('click');
 
-    expect(secondaryClickMock).toHaveBeenCalledTimes(1);
+    expect(wrapper.emitted().secondaryClick).toBeTruthy();
   });
 
   it('renders default slot', () => {


### PR DESCRIPTION
Hi team Homeday :)
I think It's better to test the emitted events instead of using mock events. This MR increases the code coverage.

Before:
![code-coverage-before](https://user-images.githubusercontent.com/64054929/85843592-9fbb3b00-b7b6-11ea-87e2-da88b2627119.png)
After:
![code-coverage-after](https://user-images.githubusercontent.com/64054929/85843064-e2304800-b7b5-11ea-8bcd-6d8b550696d5.png)

I'm gradually getting familiar with the project. I look forward to hearing your suggestion on what section of the project is better to work on.