### PR TITLE
✨ make HdIcon accessible

### DIFF
--- a/src/components/HdIcon.vue
+++ b/src/components/HdIcon.vue
@@ -1,9 +1,7 @@
 <template>
   <inline-svg
     :src="src"
-    :title="title"
     :id="id"
-    :description="description"
     :transform-source="transform"
     v-bind="$attrs"
   />
@@ -69,24 +67,22 @@ export default {
     },
     addAccessibilityTags(svg) {
       const randId = Math.floor(Math.random() * 1000);
-      const attrs = [];
       if (this.title) {
         const titleId = `${this.id || randId}-title`;
         const titleTag = document.createElementNS('http://www.w3.org/2000/svg', 'title');
-        titleTag.innerHTML = this.title;
+        titleTag.textContent = this.title;
         titleTag.id = titleId;
         svg.insertBefore(titleTag, svg.firstChild);
-        attrs.push(titleId);
+        svg.setAttribute('aria-labelledby', titleId);
       }
       if (this.description) {
         const descId = `${this.id || randId}-desc`;
         const descTag = document.createElementNS('http://www.w3.org/2000/svg', 'desc');
         descTag.id = descId;
+        descTag.textContent = this.description;
         svg.appendChild(descTag);
-        attrs.push(descId);
+        svg.setAttribute('aria-describedby', descId);
       }
-      if (attrs.length) svg.setAttribute('aria-labelledby', attrs.join(' '));
-      svg.setAttribute('role', 'img');
     },
     getFillFromClassNames(classNames) {
       if (!classNames || !this.fillFromClass) {

--- a/src/components/HdIcon.vue
+++ b/src/components/HdIcon.vue
@@ -1,6 +1,9 @@
 <template>
   <inline-svg
     :src="src"
+    :title="title"
+    :id="id"
+    :description="description"
     :transform-source="transform"
     v-bind="$attrs"
   />
@@ -21,6 +24,15 @@ export default {
       type: String,
       required: true,
     },
+    title: {
+      type: String,
+    },
+    id: {
+      type: String,
+    },
+    description: {
+      type: String,
+    },
     // to set a fill based on the path's class
     fillFromClass: {
       type: Object,
@@ -34,6 +46,8 @@ export default {
   },
   methods: {
     transform(svg) {
+      this.addAccessibilityTags(svg);
+
       if (!this.fillFromClass && !this.classFromFill) {
         return svg;
       }
@@ -52,6 +66,27 @@ export default {
       });
 
       return svg;
+    },
+    addAccessibilityTags(svg) {
+      const randId = Math.floor(Math.random() * 1000);
+      const attrs = [];
+      if (this.title) {
+        const titleId = `${this.id || randId}-title`;
+        const titleTag = document.createElementNS('http://www.w3.org/2000/svg', 'title');
+        titleTag.innerHTML = this.title;
+        titleTag.id = titleId;
+        svg.insertBefore(titleTag, svg.firstChild);
+        attrs.push(titleId);
+      }
+      if (this.description) {
+        const descId = `${this.id || randId}-desc`;
+        const descTag = document.createElementNS('http://www.w3.org/2000/svg', 'desc');
+        descTag.id = descId;
+        svg.appendChild(descTag);
+        attrs.push(descId);
+      }
+      if (attrs.length) svg.setAttribute('aria-labelledby', attrs.join(' '));
+      svg.setAttribute('role', 'img');
     },
     getFillFromClassNames(classNames) {
       if (!classNames || !this.fillFromClass) {

--- a/src/components/HdIcon.vue
+++ b/src/components/HdIcon.vue
@@ -44,7 +44,9 @@ export default {
   },
   methods: {
     transform(svg) {
-      this.addAccessibilityTags(svg);
+      const randId = Math.floor(Math.random() * 1000);
+      if (this.title) this.addTitleTag(svg, randId);
+      if (this.description) this.addDescTag(svg, randId);
 
       if (!this.fillFromClass && !this.classFromFill) {
         return svg;
@@ -65,24 +67,21 @@ export default {
 
       return svg;
     },
-    addAccessibilityTags(svg) {
-      const randId = Math.floor(Math.random() * 1000);
-      if (this.title) {
-        const titleId = `${this.id || randId}-title`;
-        const titleTag = document.createElementNS('http://www.w3.org/2000/svg', 'title');
-        titleTag.textContent = this.title;
-        titleTag.id = titleId;
-        svg.insertBefore(titleTag, svg.firstChild);
-        svg.setAttribute('aria-labelledby', titleId);
-      }
-      if (this.description) {
-        const descId = `${this.id || randId}-desc`;
-        const descTag = document.createElementNS('http://www.w3.org/2000/svg', 'desc');
-        descTag.id = descId;
-        descTag.textContent = this.description;
-        svg.appendChild(descTag);
-        svg.setAttribute('aria-describedby', descId);
-      }
+    addTitleTag(svg, randId) {
+      const titleId = `${this.id || randId}-title`;
+      const titleTag = document.createElementNS('http://www.w3.org/2000/svg', 'title');
+      titleTag.textContent = this.title;
+      titleTag.id = titleId;
+      svg.insertBefore(titleTag, svg.firstChild);
+      svg.setAttribute('aria-labelledby', titleId);
+    },
+    addDescTag(svg, randId) {
+      const descId = `${this.id || randId}-desc`;
+      const descTag = document.createElementNS('http://www.w3.org/2000/svg', 'desc');
+      descTag.id = descId;
+      descTag.textContent = this.description;
+      svg.appendChild(descTag);
+      svg.setAttribute('aria-describedby', descId);
     },
     getFillFromClassNames(classNames) {
       if (!classNames || !this.fillFromClass) {

--- a/src/components/HdIcon.vue
+++ b/src/components/HdIcon.vue
@@ -44,9 +44,7 @@ export default {
   },
   methods: {
     transform(svg) {
-      const randId = Math.floor(Math.random() * 1000);
-      if (this.title) this.addTitleTag(svg, randId);
-      if (this.description) this.addDescTag(svg, randId);
+      this.addAccessibilityTags(svg);
 
       if (!this.fillFromClass && !this.classFromFill) {
         return svg;
@@ -66,6 +64,11 @@ export default {
       });
 
       return svg;
+    },
+    addAccessibilityTags(svg) {
+      const randId = Math.floor(Math.random() * 1000);
+      if (this.title) this.addTitleTag(svg, randId);
+      if (this.description) this.addDescTag(svg, randId);
     },
     addTitleTag(svg, randId) {
       const titleId = `${this.id || randId}-title`;

--- a/tests/unit/components/HdIcon.spec.js
+++ b/tests/unit/components/HdIcon.spec.js
@@ -99,6 +99,7 @@ describe('HdIcon', () => {
 
     expect(wrapper.contains('title')).toBeTruthy();
     expect(wrapper.contains('desc')).toBeTruthy();
-    expect(wrapper.attributes('aria-labelledby')).toBe('icon-id-title icon-id-desc');
+    expect(wrapper.attributes('aria-labelledby')).toBe('icon-id-title');
+    expect(wrapper.attributes('aria-describedby')).toBe('icon-id-desc');
   });
 });

--- a/tests/unit/components/HdIcon.spec.js
+++ b/tests/unit/components/HdIcon.spec.js
@@ -99,4 +99,18 @@ describe('HdIcon', () => {
 
     expect(wrapper.html()).toMatchSnapshot();
   });
+
+  it("generates the title and desc id if it's not provided", async () => {
+    const wrapper = wrapperBuilder({
+      props: {
+        src: 'fake/icon5.svg',
+        title: 'This make me accessible.',
+        description: 'Some description.',
+      },
+    });
+
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
 });

--- a/tests/unit/components/HdIcon.spec.js
+++ b/tests/unit/components/HdIcon.spec.js
@@ -84,4 +84,21 @@ describe('HdIcon', () => {
     expect(targetedPaths.length).toBeGreaterThan(0);
     expect(targetedPaths.is(`.${TEST_CLASS}`)).toBe(true);
   });
+
+  it('adds title and desc tag to the svg', async () => {
+    const wrapper = wrapperBuilder({
+      props: {
+        src: 'fake/icon4.svg',
+        title: 'This make me accessible.',
+        description: 'Some description.',
+        id: 'icon-id',
+      },
+    });
+
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.contains('title')).toBeTruthy();
+    expect(wrapper.contains('desc')).toBeTruthy();
+    expect(wrapper.attributes('aria-labelledby')).toBe('icon-id-title icon-id-desc');
+  });
 });

--- a/tests/unit/components/HdIcon.spec.js
+++ b/tests/unit/components/HdIcon.spec.js
@@ -111,9 +111,9 @@ describe('HdIcon', () => {
 
     await wrapper.vm.$nextTick();
 
-    const titleTag = wrapper.find('title')
-    const descTag = wrapper.find('desc')
-    expect(titleTag.element.id).toMatch(/\d+-title/)
-    expect(descTag.element.id).toMatch(/\d+-desc/)
+    const titleTag = wrapper.find('title');
+    const descTag = wrapper.find('desc');
+    expect(titleTag.element.id).toMatch(/\d+-title/);
+    expect(descTag.element.id).toMatch(/\d+-desc/);
   });
 });

--- a/tests/unit/components/HdIcon.spec.js
+++ b/tests/unit/components/HdIcon.spec.js
@@ -97,9 +97,6 @@ describe('HdIcon', () => {
 
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.contains('title')).toBeTruthy();
-    expect(wrapper.contains('desc')).toBeTruthy();
-    expect(wrapper.attributes('aria-labelledby')).toBe('icon-id-title');
-    expect(wrapper.attributes('aria-describedby')).toBe('icon-id-desc');
+    expect(wrapper.html()).toMatchSnapshot();
   });
 });

--- a/tests/unit/components/HdIcon.spec.js
+++ b/tests/unit/components/HdIcon.spec.js
@@ -111,6 +111,9 @@ describe('HdIcon', () => {
 
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.html()).toMatchSnapshot();
+    const titleTag = wrapper.find('title')
+    const descTag = wrapper.find('desc')
+    expect(titleTag.element.id).toMatch(/\d+-title/)
+    expect(descTag.element.id).toMatch(/\d+-desc/)
   });
 });

--- a/tests/unit/components/__snapshots__/HdIcon.spec.js.snap
+++ b/tests/unit/components/__snapshots__/HdIcon.spec.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`HdIcon adds title and desc tag to the svg 1`] = `
+<svg aria-describedby="icon-id-desc" aria-labelledby="icon-id-title" height="50" width="50" viewBox="222 126 53 53" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" id="icon-id">
+  <title id="icon-id-title">This make me accessible.</title>
+  <path class="color1" d="M272.48 137.62L258.61 150.5L244.75 141.58L254.65 126.73L272.48 137.62Z" fill="#1895FF"></path>
+  <path class="color2" d="M242.22 176.24L222.97 160.68L230.47 145.1L243.56 155.68L242.22 176.24Z" fill="#1C3553"></path>
+  <desc id="icon-id-desc">Some description.</desc>
+</svg>
+`;
+
 exports[`HdIcon renders as expected 1`] = `
 <svg height="50" width="50" viewBox="222 126 53 53" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
   <path class="color1" d="M272.48 137.62L258.61 150.5L244.75 141.58L254.65 126.73L272.48 137.62Z" fill="#1895FF"></path>

--- a/tests/unit/components/__snapshots__/HdIcon.spec.js.snap
+++ b/tests/unit/components/__snapshots__/HdIcon.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HdIcon renders as expected 1`] = `
-<svg height="50" width="50" viewBox="222 126 53 53" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
+<svg role="img" height="50" width="50" viewBox="222 126 53 53" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
   <path class="color1" d="M272.48 137.62L258.61 150.5L244.75 141.58L254.65 126.73L272.48 137.62Z" fill="#1895FF"></path>
   <path class="color2" d="M242.22 176.24L222.97 160.68L230.47 145.1L243.56 155.68L242.22 176.24Z" fill="#1C3553"></path>
 </svg>

--- a/tests/unit/components/__snapshots__/HdIcon.spec.js.snap
+++ b/tests/unit/components/__snapshots__/HdIcon.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HdIcon renders as expected 1`] = `
-<svg role="img" height="50" width="50" viewBox="222 126 53 53" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
+<svg height="50" width="50" viewBox="222 126 53 53" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
   <path class="color1" d="M272.48 137.62L258.61 150.5L244.75 141.58L254.65 126.73L272.48 137.62Z" fill="#1895FF"></path>
   <path class="color2" d="M242.22 176.24L222.97 160.68L230.47 145.1L243.56 155.68L242.22 176.24Z" fill="#1C3553"></path>
 </svg>

--- a/tests/unit/components/__snapshots__/HdIcon.spec.js.snap
+++ b/tests/unit/components/__snapshots__/HdIcon.spec.js.snap
@@ -9,6 +9,15 @@ exports[`HdIcon adds title and desc tag to the svg 1`] = `
 </svg>
 `;
 
+exports[`HdIcon generates the title and desc id if it's not provided 1`] = `
+<svg aria-describedby="476-desc" aria-labelledby="476-title" height="50" width="50" viewBox="222 126 53 53" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
+  <title id="476-title">This make me accessible.</title>
+  <path class="color1" d="M272.48 137.62L258.61 150.5L244.75 141.58L254.65 126.73L272.48 137.62Z" fill="#1895FF"></path>
+  <path class="color2" d="M242.22 176.24L222.97 160.68L230.47 145.1L243.56 155.68L242.22 176.24Z" fill="#1C3553"></path>
+  <desc id="476-desc">Some description.</desc>
+</svg>
+`;
+
 exports[`HdIcon renders as expected 1`] = `
 <svg height="50" width="50" viewBox="222 126 53 53" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
   <path class="color1" d="M272.48 137.62L258.61 150.5L244.75 141.58L254.65 126.73L272.48 137.62Z" fill="#1895FF"></path>

--- a/tests/unit/components/__snapshots__/HdIcon.spec.js.snap
+++ b/tests/unit/components/__snapshots__/HdIcon.spec.js.snap
@@ -9,15 +9,6 @@ exports[`HdIcon adds title and desc tag to the svg 1`] = `
 </svg>
 `;
 
-exports[`HdIcon generates the title and desc id if it's not provided 1`] = `
-<svg aria-describedby="476-desc" aria-labelledby="476-title" height="50" width="50" viewBox="222 126 53 53" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
-  <title id="476-title">This make me accessible.</title>
-  <path class="color1" d="M272.48 137.62L258.61 150.5L244.75 141.58L254.65 126.73L272.48 137.62Z" fill="#1895FF"></path>
-  <path class="color2" d="M242.22 176.24L222.97 160.68L230.47 145.1L243.56 155.68L242.22 176.24Z" fill="#1C3553"></path>
-  <desc id="476-desc">Some description.</desc>
-</svg>
-`;
-
 exports[`HdIcon renders as expected 1`] = `
 <svg height="50" width="50" viewBox="222 126 53 53" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
   <path class="color1" d="M272.48 137.62L258.61 150.5L244.75 141.58L254.65 126.73L272.48 137.62Z" fill="#1895FF"></path>


### PR DESCRIPTION
Hi!

This PR improves HdIcon accessibility as suggested in https://github.com/homeday-de/homeday-blocks/issues/414
Changes follow the tips on accessible SVGs from the [linked article](https://css-tricks.com/accessible-svgs/) - the title and desc tags are added to the SVG, along with `aria-labelledby` and `role` attributes.

Looking forward to the review 🙂 