### PR TITLE
[F] Forward attributes from HdInput to <input>

### DIFF
--- a/src/components/form/HdInput.vue
+++ b/src/components/form/HdInput.vue
@@ -18,7 +18,6 @@
       :name="name"
       :placeholder="isActive && placeholder !== undefined ? placeholder : ''"
       :required="required"
-      :autofocus="autofocus"
       :disabled="disabled"
       class="field__input"
       ref="input"
@@ -88,10 +87,6 @@ export default {
     autocomplete: {
       type: String,
       default: 'on',
-    },
-    autofocus: {
-      type: Boolean,
-      default: false,
     },
     min: {
       type: Number,

--- a/src/components/form/HdInput.vue
+++ b/src/components/form/HdInput.vue
@@ -10,6 +10,7 @@
       class="field__icon"
     >
     <input
+      v-bind="$attrs"
       :autocomplete="autocomplete"
       :value="value"
       :type="currentType"
@@ -58,6 +59,7 @@ import {
 
 export default {
   name: 'HdInput',
+  inheritAttrs: false,
   props: {
     label: {
       type: String,

--- a/tests/unit/components/form/HdInput.spec.js
+++ b/tests/unit/components/form/HdInput.spec.js
@@ -280,4 +280,14 @@ describe('HdInput', () => {
 
     expect(wrapper.find(ERROR_SELECTOR).text()).toBe(errorMsg);
   });
+
+  it('forwards attributes to <input>', () => {
+    const wrapper = wrapperBuilder({
+      props: {
+        readonly: true,
+      },
+    });
+
+    expect(wrapper.find('input').attributes().readonly).toBe('readonly');
+  });
 });


### PR DESCRIPTION
Closes #482 

---

Forwarding all attributes from `HdInput` to `<input>`.

- `autofocus` can be removed, as it will be off by default
- `disabled` could be removed in favor of `:disabled` selector

What do you think about the items above? I wouldn't address them in this PR and open issues instead.