### PR TITLE
[F] [CE-1541] extend HdButton

### DIFF
--- a/src/components/buttons/HdButton.vue
+++ b/src/components/buttons/HdButton.vue
@@ -45,9 +45,3 @@ export default {
   },
 };
 </script>
-
-<style lang="scss" scoped>
-.btn {
-  width: 100%;
-}
-</style>

--- a/src/components/buttons/HdButton.vue
+++ b/src/components/buttons/HdButton.vue
@@ -29,6 +29,10 @@ export default {
         return allTypes.includes(value);
       },
     },
+    isInDarkBackground: {
+      type: Boolean,
+      default: false,
+    },
   },
   computed: {
     computedClasses() {
@@ -37,6 +41,10 @@ export default {
 
       if (this.modifier) {
         classes.push(`${baseClass}--${this.modifier}`);
+      }
+
+      if (this.isInDarkBackground) {
+        classes.push(`${baseClass}--dark-background`);
       }
 
       return classes;

--- a/src/components/buttons/HdButton.vue
+++ b/src/components/buttons/HdButton.vue
@@ -16,7 +16,6 @@
 import HdIcon from 'homeday-blocks/src/components/HdIcon.vue';
 
 export const TYPES = {
-  DEFAULT: '',
   PRIMARY: 'primary',
   SECONDARY: 'secondary',
   TERTIARY: 'tertiary',
@@ -32,7 +31,7 @@ export default {
   props: {
     modifier: {
       type: String,
-      default: TYPES.DEFAULT,
+      default: TYPES.PRIMARY,
       validator(value) {
         const allTypes = Object.values(TYPES);
 

--- a/src/components/buttons/HdButton.vue
+++ b/src/components/buttons/HdButton.vue
@@ -13,7 +13,6 @@ export const TYPES = {
   PRIMARY: 'primary',
   SECONDARY: 'secondary',
   TERTIARY: 'tertiary',
-  QUATERNARY: 'quaternary',
   FLAT: 'flat',
   GHOST: 'ghost',
 };

--- a/src/components/buttons/HdButton.vue
+++ b/src/components/buttons/HdButton.vue
@@ -13,6 +13,7 @@ export const TYPES = {
   PRIMARY: 'primary',
   SECONDARY: 'secondary',
   TERTIARY: 'tertiary',
+  QUATERNARY: 'quaternary',
   FLAT: 'flat',
   GHOST: 'ghost',
 };

--- a/src/components/buttons/HdButton.vue
+++ b/src/components/buttons/HdButton.vue
@@ -3,11 +3,18 @@
     v-on="$listeners"
     :class="computedClasses"
   >
+    <HdIcon
+      v-if="iconSrc"
+      :src="iconSrc"
+      class="btn__icon"
+    />
     <slot />
   </button>
 </template>
 
 <script>
+import HdIcon from 'homeday-blocks/src/components/HdIcon.vue';
+
 export const TYPES = {
   DEFAULT: '',
   PRIMARY: 'primary',
@@ -19,6 +26,9 @@ export const TYPES = {
 
 export default {
   name: 'HdButton',
+  components: {
+    HdIcon,
+  },
   props: {
     modifier: {
       type: String,
@@ -32,6 +42,10 @@ export default {
     isInDarkBackground: {
       type: Boolean,
       default: false,
+    },
+    iconSrc: {
+      type: String,
+      default: '',
     },
   },
   computed: {
@@ -52,3 +66,15 @@ export default {
   },
 };
 </script>
+
+<style lang="scss">
+@import 'homeday-blocks/src/styles/_variables.scss';
+
+.btn__icon {
+  margin-right: $inline-xs;
+
+  path {
+    fill: currentColor;
+  }
+}
+</style>

--- a/src/stories/HdButton.stories.js
+++ b/src/stories/HdButton.stories.js
@@ -26,6 +26,24 @@ Object.entries(TYPES)
     },
   })));
 
+Object.entries(TYPES)
+  .forEach(([type, modifier]) => stories.add(`${type} -- DISABLED`, () => ({
+    components: { HdButton },
+    data() {
+      return { type, modifier };
+    },
+    template: `
+      <HdButton
+        :modifier=modifier
+        @click="onClick"
+        disabled
+      >{{ type }}</HdButton>
+    `,
+    methods: {
+      onClick: action('onClick'),
+    },
+  })));
+
 stories
   .add('Playground 🎛', () => ({
     components: { HdButton },

--- a/src/stories/HdButton.stories.js
+++ b/src/stories/HdButton.stories.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from '@storybook/vue';
 import { action } from '@storybook/addon-actions';
-import { text, select } from '@storybook/addon-knobs';
+import { text, boolean, select } from '@storybook/addon-knobs';
 import {
   HdButton,
   HdButtonTypes as TYPES,
@@ -26,24 +26,6 @@ Object.entries(TYPES)
     },
   })));
 
-Object.entries(TYPES)
-  .forEach(([type, modifier]) => stories.add(`${type} -- DISABLED`, () => ({
-    components: { HdButton },
-    data() {
-      return { type, modifier };
-    },
-    template: `
-      <HdButton
-        :modifier=modifier
-        @click="onClick"
-        disabled
-      >{{ type }}</HdButton>
-    `,
-    methods: {
-      onClick: action('onClick'),
-    },
-  })));
-
 stories
   .add('Playground 🎛', () => ({
     components: { HdButton },
@@ -56,14 +38,44 @@ stories
         type: String,
         default: select('Modifier', Object.values(TYPES), TYPES.default),
       },
+      isInDarkBackground: {
+        default: boolean('Dark background', false),
+      },
+      disabled: {
+        default: boolean('Disabled', false),
+      },
+    },
+    data() {
+      return {
+        styleWrapper: {
+          position: 'relative',
+          width: '100vw',
+          height: '100vh',
+          padding: '50px',
+        },
+        styleDarkBackground: {
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#1C3553',
+          zIndex: -1,
+        },
+      };
     },
     methods: {
       onClick: action('onClick'),
     },
     template: `
-      <HdButton
-        :modifier=modifier
-        @click="onClick"
-      >{{ text }}</HdButton>
+      <div :style="styleWrapper">
+        <HdButton
+          :modifier=modifier
+          :isInDarkBackground=isInDarkBackground
+          :disabled=disabled
+          @click="onClick"
+        >{{ text }}</HdButton>
+        <div v-if="isInDarkBackground" :style="styleDarkBackground" />
+      </div>
     `,
   }), { percy: { skip: true } });

--- a/src/stories/HdButton.stories.js
+++ b/src/stories/HdButton.stories.js
@@ -7,6 +7,8 @@ import {
   HdButtonTypes as TYPES,
 } from 'homeday-blocks';
 
+import { plusIcon } from 'homeday-blocks/src/assets/small-icons';
+
 const stories = storiesOf('Components|HdButton', module);
 
 Object.entries(TYPES)
@@ -44,9 +46,13 @@ stories
       disabled: {
         default: boolean('Disabled', false),
       },
+      showIcon: {
+        default: boolean('Show icon', false),
+      },
     },
     data() {
       return {
+        plusIcon,
         styleWrapper: {
           position: 'relative',
           width: '100vw',
@@ -70,6 +76,15 @@ stories
     template: `
       <div :style="styleWrapper">
         <HdButton
+          v-if="showIcon"
+          :modifier=modifier
+          :isInDarkBackground=isInDarkBackground
+          :disabled=disabled
+          @click="onClick"
+          :iconSrc=plusIcon
+        >{{ text }}</HdButton>
+        <HdButton
+          v-else
           :modifier=modifier
           :isInDarkBackground=isInDarkBackground
           :disabled=disabled

--- a/src/styles/buttons.scss
+++ b/src/styles/buttons.scss
@@ -85,7 +85,7 @@ $button-transition: all $time-s ease-in-out;
   }
 
   &[disabled],
-  &.btn--primary__disabled {
+  &.btn--disabled {
     background: getShade($neutral-gray, 50);
     box-shadow: none;
     color: getShade($neutral-gray, 90);
@@ -144,7 +144,7 @@ $button-transition: all $time-s ease-in-out;
   }
 
   &[disabled],
-  &.btn--secondary__disabled {
+  &.btn--disabled {
     border: 2px solid getShade($neutral-gray, 60);
     color: getShade($neutral-gray, 70);
     box-shadow: none;
@@ -195,7 +195,7 @@ $button-transition: all $time-s ease-in-out;
   }
 
   &[disabled],
-  &.btn--tertiary__disabled {
+  &.btn--disabled {
     border: 2px solid transparent;
     background-color: getShade($neutral-gray, 40);
     color: getShade($neutral-gray, 70);

--- a/src/styles/buttons.scss
+++ b/src/styles/buttons.scss
@@ -193,6 +193,27 @@ $button-transition: all $time-s ease-in-out;
   &:active {
     background-color: getShade($secondary-color, 70);
   }
+
+  &[disabled],
+  &.btn--tertiary__disabled {
+    border: 2px solid transparent;
+    background-color: getShade($neutral-gray, 40);
+    color: getShade($neutral-gray, 70);
+    box-shadow: none;
+
+    &:after {
+      display: none;
+    }
+
+    &:hover,
+    &:active,
+    &:focus {
+      background: getShade($neutral-gray, 40);
+      cursor: default;
+      box-shadow: none;
+      transform: none;
+    }
+  }
 }
 
 .btn--flat {

--- a/src/styles/buttons.scss
+++ b/src/styles/buttons.scss
@@ -4,7 +4,7 @@
 $button-inset-padding: 16px;
 $button-transition: all $time-s ease-in-out;
 
-@mixin btn-ripple($ripple-color: $white) {
+@mixin btn-ripple($ripple-color: $white, $blend-mode: normal, $opacity: 0.2) {
   position: relative;
   overflow: hidden;
   transform: translate3d(0, 0, 0);
@@ -21,7 +21,7 @@ $button-transition: all $time-s ease-in-out;
     background-image: radial-gradient(circle, $ripple-color 10%, transparent 10.01%);
     background-repeat: no-repeat;
     background-position: 50%;
-    mix-blend-mode: normal;
+    mix-blend-mode: $blend-mode;
     transform: scale(10, 10);
     opacity: 0;
     transition: transform 0.3s, opacity 0.8s;
@@ -30,7 +30,7 @@ $button-transition: all $time-s ease-in-out;
   &:active {
     &::after {
       transform: scale(0, 0);
-      opacity: .2;
+      opacity: $opacity;
       transition: 0s;
     }
   }
@@ -41,16 +41,16 @@ $button-transition: all $time-s ease-in-out;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-family: $font-primary;
-  font-weight: 600;
-  font-size: 16px;
-  line-height: 28px;
   margin: 0;
   padding: $stack-s $inline-l;
   border: 0;
   border-radius: 2px;
   outline: 0;
   background-color: transparent;
+  font-family: $font-primary;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 28px;
   text-align: center;
   text-decoration: none;
   -webkit-appearance: none;
@@ -62,7 +62,7 @@ $button-transition: all $time-s ease-in-out;
 }
 
 .btn--primary {
-  @include btn-ripple($white);
+  @include btn-ripple;
 
   background-color: getShade($secondary-color, 110);
   box-shadow: 0px 3px 2px rgba(0, 0, 0, 0.12), 0px 0px 4px rgba(0, 0, 0, 0.24);
@@ -105,10 +105,9 @@ $button-transition: all $time-s ease-in-out;
 }
 
 .btn--secondary {
-  @include btn-ripple($white);
+  @include btn-ripple;
 
-  padding-top: #{$stack-s - 2px}; // adjustment for the border
-  padding-bottom: #{$stack-s - 2px}; // adjustment for the border
+  padding: #{$stack-s - 2px} #{$inline-l - 2px}; // adjustment for the border-width of 2px
   border: 2px solid getShade($secondary-color, 110);
   color: getShade($secondary-color, 110);
   transition: 
@@ -170,38 +169,29 @@ $button-transition: all $time-s ease-in-out;
 }
 
 .btn--tertiary {
-  @include font('body');
-  display: inline-block;
-  color: getShade($secondary-color, 110);
-  transition: $button-transition;
-  font-weight: 600;
-  position: relative;
-  width: auto;
+  @include btn-ripple(getShade($secondary-color, 80), multiply, 0.4);
 
-  &:after {
-    content: "";
-    width: calc(100% - #{2 * $button-inset-padding});
-    height: 2px;
-    background-color: getShade($secondary-color, 110);
-    position: absolute;
-    bottom: 12px;
-    left: 0;
-    right: 0;
-    margin: auto;
+  padding: #{$stack-s - 2px} #{$inline-l - 2px}; // adjustment for the border-width of 2px
+  border: 2px solid transparent;
+  background-color: getShade($secondary-color, 70);
+  color: getShade($secondary-color, 110);
+  transition: 
+    background-color 0.3s ease-in-out,
+    border 0.3s ease-in-out,
+    padding 0.3s ease-in-out;
+
+  &:hover {
+    background-color: transparent;
+    border: 2px solid getShade($secondary-color, 110);
   }
-  &:before {
-    content: "";
-    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMCA1Ij48ZyBpZD0iSG9tZXBhZ2UiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgaWQ9ImhvbWVwYWdlXzMuMC5fUHJpbWFyeV9OYXZpZ2F0aW9uX0V4cGFuZGVkIiBmaWxsPSIjMTg5NUZGIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMTMwMC4wMDAwMDAsIC00OS4wMDAwMDApIj48ZyBpZD0iTW9sZWN1bGVzL2hlYWRlciIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTEuMDAwMDAwLCAwLjAwMDAwMCkiPjxnIGlkPSJOYXZpZ2F0aW9uLS1wcmltYXJ5IiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxLjAwMDAwMCwgMC4wMDAwMDApIj48ZyBpZD0iQ29udGVudCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTQ0LjAwMDAwMCwgMTYuMDAwMDAwKSI+PGcgaWQ9ImF0b20vaWNvbi9pY19tZW51YXJyb3ctZG93bi1ibHVlIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxMTU2LjAwMDAwMCwgMzMuMDAwMDAwKSI+PHBvbHlnb24gaWQ9ImljX21lbnVhcnJvdy1kb3duLWJsdWUiIHBvaW50cz0iMi4wODMzMzMzMyA2LjI4MTgwMTM0IDUuNTgyMTc2MTMgMi41IDIuMDgzMzMzMzMgLTEuMjgxODAxMzQgMi44NDMzNDc1OCAtMi4wODMzMzMzMyA3LjA4MzMzMzMzIDIuNSAyLjg0MzM0NzU4IDcuMDgzMzMzMzMiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDQuNTgzMzMzLCAyLjUwMDAwMCkgc2NhbGUoMSwgLTEpIHJvdGF0ZSgtOTAuMDAwMDAwKSB0cmFuc2xhdGUoLTQuNTgzMzMzLCAtMi41MDAwMDApICIvPjwvZz48L2c+PC9nPjwvZz48L2c+PC9nPjwvc3ZnPg==);    
-    background-repeat: no-repeat;
-    height: 10px;
-    width: 15px;
-    display: block;
-    position: absolute;
-    right: -4px;
-    bottom: 20px;
+
+  &:focus {
+    background-color: transparent;
+    border: 2px solid getShade($secondary-color, 110);
   }
-  &:hover:before {
-    animation: bounceBack 500ms normal ease-in-out;
+
+  &:active {
+    background-color: getShade($secondary-color, 70);
   }
 }
 

--- a/src/styles/buttons.scss
+++ b/src/styles/buttons.scss
@@ -97,7 +97,7 @@ $button-transition: all $time-s ease-in-out;
     &:hover,
     &:active,
     &:focus {
-      background: getShade($neutral-gray, 50);
+      background-color: getShade($neutral-gray, 50);
       cursor: default;
       box-shadow: none;
       transform: none;
@@ -156,7 +156,7 @@ $button-transition: all $time-s ease-in-out;
     &:hover,
     &:active,
     &:focus {
-      background: transparent;
+      background-color: transparent;
       cursor: default;
       box-shadow: none;
       transform: none;
@@ -192,12 +192,23 @@ $button-transition: all $time-s ease-in-out;
 
   &:active {
     background-color: getShade($secondary-color, 70);
+    border: 2px solid transparent;
+  }
+
+  &.btn--dark-background {
+    background-color: rgba(white, 0.2);
+    color: white;
+
+    &:hover,
+    &:focus {
+      border: 2px solid white;
+    }
   }
 
   &[disabled],
   &.btn--disabled {
-    border: 2px solid transparent;
     background-color: getShade($neutral-gray, 40);
+    border: 2px solid transparent;
     color: getShade($neutral-gray, 70);
     box-shadow: none;
 
@@ -208,10 +219,15 @@ $button-transition: all $time-s ease-in-out;
     &:hover,
     &:active,
     &:focus {
-      background: getShade($neutral-gray, 40);
+      background-color: getShade($neutral-gray, 40);
+      border: 2px solid transparent;
       cursor: default;
       box-shadow: none;
       transform: none;
+    }
+
+    &.btn--dark-background {
+      background-color: rgba(120, 143, 171, 0.7);
     }
   }
 }

--- a/src/styles/buttons.scss
+++ b/src/styles/buttons.scss
@@ -125,6 +125,12 @@ $button-transition: all $time-s ease-in-out;
   }
 }
 
+.btn--quaternary {
+  background: getShade($secondary-color, 70);
+  border: 1px solid transparent;
+  color: getShade($secondary-color, 110);
+}
+
 .btn--flat {
   position: relative;
   background-color: $white;

--- a/src/styles/buttons.scss
+++ b/src/styles/buttons.scss
@@ -113,6 +113,7 @@ $button-transition: all $time-s ease-in-out;
   color: getShade($secondary-color, 110);
   transition: 
     background-color 0.3s ease-in-out,
+    border 0.3s ease-in-out,
     box-shadow 0.3s ease-in-out,
     color 0.3s ease-in-out;
 
@@ -133,8 +134,18 @@ $button-transition: all $time-s ease-in-out;
     background-color: #1895FF;
   }
 
+  &.btn--dark-background {
+    border: 2px solid $white;
+    color: $white;
+
+    &:hover,
+    &:focus {
+      border: 2px solid getShade($secondary-color, 110);
+    }
+  }
+
   &[disabled],
-  &.btn--primary__disabled {
+  &.btn--secondary__disabled {
     border: 2px solid getShade($neutral-gray, 60);
     color: getShade($neutral-gray, 70);
     box-shadow: none;
@@ -150,6 +161,10 @@ $button-transition: all $time-s ease-in-out;
       cursor: default;
       box-shadow: none;
       transform: none;
+    }
+
+    &.btn--dark-background {
+      color: getShade($neutral-gray, 60);
     }
   }
 }

--- a/src/styles/buttons.scss
+++ b/src/styles/buttons.scss
@@ -16,28 +16,32 @@ $button-transition: all $time-s ease-in-out;
   margin: 0;
   padding: $stack-s $inline-l;
   border: 0;
+  border-radius: 2px;
   outline: 0;
   background-color: transparent;
-  border-radius: 1px;
   text-align: center;
   text-decoration: none;
   -webkit-appearance: none;
   -moz-appearance: none;
+
+  &:hover {
+    cursor: pointer;
+  }
 }
 
 .btn--primary {
   background-color: getShade($secondary-color, 110);
   box-shadow: 0px 3px 2px rgba(0, 0, 0, 0.12), 0px 0px 4px rgba(0, 0, 0, 0.24);
   color: $white;
-  transition: background-color 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
+  transition: 
+    background-color 0.3s ease-in-out,
+    box-shadow 0.3s ease-in-out;
 
   &:hover {
-    cursor: pointer;
     box-shadow: 0px 6px 12px rgba(0, 0, 0, 0.3);
   }
 
   &:focus {
-    border-radius: 2px;
     box-shadow: 0px 0px 14px #1895FF, 0px 0px 1px #1895FF;
   }
 
@@ -55,7 +59,7 @@ $button-transition: all $time-s ease-in-out;
     width: 100%;
     height: 100%;
     pointer-events: none;
-    background-image: radial-gradient(circle, #FFF 10%, transparent 10.01%);
+    background-image: radial-gradient(circle, $white 10%, transparent 10.01%);
     background-repeat: no-repeat;
     background-position: 50%;
     mix-blend-mode: normal;
@@ -89,6 +93,84 @@ $button-transition: all $time-s ease-in-out;
     &:active,
     &:focus {
       background: getShade($neutral-gray, 50);
+      cursor: default;
+      box-shadow: none;
+      transform: none;
+    }
+  }
+}
+
+.btn--secondary {
+  padding-top: #{$stack-s - 2px}; // adjustment for the border
+  padding-bottom: #{$stack-s - 2px}; // adjustment for the border
+  border: 2px solid getShade($secondary-color, 110);
+  color: getShade($secondary-color, 110);
+  transition: 
+    background-color 0.3s ease-in-out,
+    box-shadow 0.3s ease-in-out,
+    color 0.3s ease-in-out;
+
+  &:hover {
+    box-shadow: 0px 6px 12px rgba(0, 0, 0, 0.3);
+    background-color: getShade($secondary-color, 110);
+    color: $white;
+  }
+
+  &:focus {
+    box-shadow: 0px 0px 14px #1895FF, 0px 0px 1px #1895FF;
+    background-color: getShade($secondary-color, 110);
+    color: $white;
+  }
+
+  /*** Properties for Ripple effect on click ***/
+  position: relative;
+  overflow: hidden;
+  transform: translate3d(0, 0, 0);
+
+  &::after {
+    content: "";
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    background-image: radial-gradient(circle, $white 10%, transparent 10.01%);
+    background-repeat: no-repeat;
+    background-position: 50%;
+    mix-blend-mode: normal;
+    transform: scale(10, 10);
+    opacity: 0;
+    transition: transform 0.3s, opacity 0.8s;
+  }
+
+  &:active {
+    // ToDo: Ask design team which color is this.
+    background-color: #1895FF;
+    
+    &::after {
+      transform: scale(0, 0);
+      opacity: .2;
+      transition: 0s;
+    }
+  }
+  /*** Properties for Ripple effect on click ***/
+
+  &[disabled],
+  &.btn--primary__disabled {
+    border: 2px solid getShade($neutral-gray, 60);
+    color: getShade($neutral-gray, 70);
+    box-shadow: none;
+
+    &:after {
+      display: none;
+    }
+
+    &:hover,
+    &:active,
+    &:focus {
+      background: transparent;
       cursor: default;
       box-shadow: none;
       transform: none;

--- a/src/styles/buttons.scss
+++ b/src/styles/buttons.scss
@@ -5,87 +5,94 @@ $button-inset-padding: 16px;
 $button-transition: all $time-s ease-in-out;
 
 .btn {
-  @include font('body');
+  box-sizing: border-box;
   display: inline-flex;
-  text-decoration: none;
-  border: none;
-  border-radius: $default-border-radius;
-  background-color: transparent;
-  padding: 13px $stack-m;
-  justify-content: center;
-  width: auto;
   align-items: center;
+  justify-content: center;
+  font-family: $font-primary;
   font-weight: 600;
+  font-size: 16px;
+  line-height: 28px;
+  margin: 0;
+  padding: $stack-s $inline-l;
+  border: 0;
+  outline: 0;
+  background-color: transparent;
+  border-radius: 1px;
   text-align: center;
-  &:hover {
-    cursor: pointer;
-  }
+  text-decoration: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
 }
 
-.btn--primary,
-.btn--secondary {
+.btn--primary {
   background-color: getShade($secondary-color, 110);
+  box-shadow: 0px 3px 2px rgba(0, 0, 0, 0.12), 0px 0px 4px rgba(0, 0, 0, 0.24);
   color: $white;
-  font-family: $font-primary;
-  width: 100%;
-  font-size: 16px;
-  height: 52px;
-  padding: 0 $stack-m;
-  box-shadow: 0 2px 2px 0 rgba(0,0,0,0.3);
-  transition: $button-transition;
+  transition: background-color 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
+
   &:hover {
-    color: $white;
-    box-shadow: 0 3px 2px 0 rgba(0,0,0,0.3);
-    background-color: getShade($secondary-color, 110);
-    transform: translateY(-1px);
+    cursor: pointer;
+    box-shadow: 0px 6px 12px rgba(0, 0, 0, 0.3);
   }
-  
-  // Ripple effect on click
+
+  &:focus {
+    border-radius: 2px;
+    box-shadow: 0px 0px 14px #1895FF, 0px 0px 1px #1895FF;
+  }
+
+  /*** Properties for Ripple effect on click ***/
   position: relative;
   overflow: hidden;
-  transform: translate3d(0,0,0);
-  &:after {
+  transform: translate3d(0, 0, 0);
+
+  &::after {
     content: "";
     display: block;
     position: absolute;
-    width: 100%;
-    height: 100%;
     top: 0;
     left: 0;
+    width: 100%;
+    height: 100%;
     pointer-events: none;
-    background-image: radial-gradient(circle,#000 10%,transparent 10.01%);
+    background-image: radial-gradient(circle, #FFF 10%, transparent 10.01%);
     background-repeat: no-repeat;
     background-position: 50%;
-    transform: scale(10,10);
+    mix-blend-mode: normal;
+    transform: scale(10, 10);
     opacity: 0;
-    transition: transform 300ms, opacity 0.8s;
-
-  }
-  &:active:after {
-    transform: scale(0,0);
-    opacity: .2;
-    transition: 0s;
+    transition: transform 0.3s, opacity 0.8s;
   }
 
-  @media (min-width: $break-tablet) {
-    font-size: 18px;
-    width: auto;
+  &:active {
+    // ToDo: Ask design team which color is this.
+    background-color: #1895FF;
+    
+    &::after {
+      transform: scale(0, 0);
+      opacity: .2;
+      transition: 0s;
+    }
   }
-}
+  /*** Properties for Ripple effect on click ***/
 
-.btn--primary[disabled],
-.btn--primary-disabled {
-  background-color: getShade($neutral-gray, 60);
-  color: $white;
-  box-shadow: 0 0 2px 0 rgba(0,0,0,0.12), 0 2px 2px 0 rgba(0,0,0,0.24);
-  &:after {
-    display: none;
-  }
-  &:hover, &:active, &:focus, &:active:focus {
-    background-color: getShade($neutral-gray, 60);
-    cursor: not-allowed;
+  &[disabled],
+  &.btn--primary__disabled {
+    background: getShade($neutral-gray, 50);
     box-shadow: none;
-    transform: none;
+
+    &:after {
+      display: none;
+    }
+
+    &:hover,
+    &:active,
+    &:focus {
+      background: getShade($neutral-gray, 50);
+      cursor: default;
+      box-shadow: none;
+      transform: none;
+    }
   }
 }
 
@@ -123,12 +130,6 @@ $button-transition: all $time-s ease-in-out;
   &:hover:before {
     animation: bounceBack 500ms normal ease-in-out;
   }
-}
-
-.btn--quaternary {
-  background: getShade($secondary-color, 70);
-  border: 1px solid transparent;
-  color: getShade($secondary-color, 110);
 }
 
 .btn--flat {

--- a/src/styles/buttons.scss
+++ b/src/styles/buttons.scss
@@ -4,6 +4,38 @@
 $button-inset-padding: 16px;
 $button-transition: all $time-s ease-in-out;
 
+@mixin btn-ripple($ripple-color: $white) {
+  position: relative;
+  overflow: hidden;
+  transform: translate3d(0, 0, 0);
+
+  &::after {
+    content: "";
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    background-image: radial-gradient(circle, $ripple-color 10%, transparent 10.01%);
+    background-repeat: no-repeat;
+    background-position: 50%;
+    mix-blend-mode: normal;
+    transform: scale(10, 10);
+    opacity: 0;
+    transition: transform 0.3s, opacity 0.8s;
+  }
+
+  &:active {
+    &::after {
+      transform: scale(0, 0);
+      opacity: .2;
+      transition: 0s;
+    }
+  }
+}
+
 .btn {
   box-sizing: border-box;
   display: inline-flex;
@@ -30,6 +62,8 @@ $button-transition: all $time-s ease-in-out;
 }
 
 .btn--primary {
+  @include btn-ripple($white);
+
   background-color: getShade($secondary-color, 110);
   box-shadow: 0px 3px 2px rgba(0, 0, 0, 0.12), 0px 0px 4px rgba(0, 0, 0, 0.24);
   color: $white;
@@ -45,40 +79,10 @@ $button-transition: all $time-s ease-in-out;
     box-shadow: 0px 0px 14px #1895FF, 0px 0px 1px #1895FF;
   }
 
-  /*** Properties for Ripple effect on click ***/
-  position: relative;
-  overflow: hidden;
-  transform: translate3d(0, 0, 0);
-
-  &::after {
-    content: "";
-    display: block;
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    pointer-events: none;
-    background-image: radial-gradient(circle, $white 10%, transparent 10.01%);
-    background-repeat: no-repeat;
-    background-position: 50%;
-    mix-blend-mode: normal;
-    transform: scale(10, 10);
-    opacity: 0;
-    transition: transform 0.3s, opacity 0.8s;
-  }
-
   &:active {
     // ToDo: Ask design team which color is this.
     background-color: #1895FF;
-    
-    &::after {
-      transform: scale(0, 0);
-      opacity: .2;
-      transition: 0s;
-    }
   }
-  /*** Properties for Ripple effect on click ***/
 
   &[disabled],
   &.btn--primary__disabled {
@@ -101,6 +105,8 @@ $button-transition: all $time-s ease-in-out;
 }
 
 .btn--secondary {
+  @include btn-ripple($white);
+
   padding-top: #{$stack-s - 2px}; // adjustment for the border
   padding-bottom: #{$stack-s - 2px}; // adjustment for the border
   border: 2px solid getShade($secondary-color, 110);
@@ -122,40 +128,10 @@ $button-transition: all $time-s ease-in-out;
     color: $white;
   }
 
-  /*** Properties for Ripple effect on click ***/
-  position: relative;
-  overflow: hidden;
-  transform: translate3d(0, 0, 0);
-
-  &::after {
-    content: "";
-    display: block;
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    pointer-events: none;
-    background-image: radial-gradient(circle, $white 10%, transparent 10.01%);
-    background-repeat: no-repeat;
-    background-position: 50%;
-    mix-blend-mode: normal;
-    transform: scale(10, 10);
-    opacity: 0;
-    transition: transform 0.3s, opacity 0.8s;
-  }
-
   &:active {
     // ToDo: Ask design team which color is this.
     background-color: #1895FF;
-    
-    &::after {
-      transform: scale(0, 0);
-      opacity: .2;
-      transition: 0s;
-    }
   }
-  /*** Properties for Ripple effect on click ***/
 
   &[disabled],
   &.btn--primary__disabled {

--- a/src/styles/buttons.scss
+++ b/src/styles/buttons.scss
@@ -69,7 +69,8 @@ $button-transition: all $time-s ease-in-out;
   color: $white;
   transition: 
     background-color 0.3s ease-in-out,
-    box-shadow 0.3s ease-in-out;
+    box-shadow 0.3s ease-in-out,
+    color 0.3s ease-in-out;
 
   &:hover {
     box-shadow: 0px 6px 12px rgba(0, 0, 0, 0.3);
@@ -80,7 +81,6 @@ $button-transition: all $time-s ease-in-out;
   }
 
   &:active {
-    // ToDo: Ask design team which color is this.
     background-color: getShade($secondary-color, 110);
   }
 
@@ -88,6 +88,7 @@ $button-transition: all $time-s ease-in-out;
   &.btn--primary__disabled {
     background: getShade($neutral-gray, 50);
     box-shadow: none;
+    color: getShade($neutral-gray, 90);
 
     &:after {
       display: none;

--- a/src/styles/buttons.scss
+++ b/src/styles/buttons.scss
@@ -76,12 +76,12 @@ $button-transition: all $time-s ease-in-out;
   }
 
   &:focus {
-    box-shadow: 0px 0px 14px #1895FF, 0px 0px 1px #1895FF;
+    box-shadow: 0px 0px 14px getShade($secondary-color, 110), 0px 0px 1px getShade($secondary-color, 110);
   }
 
   &:active {
     // ToDo: Ask design team which color is this.
-    background-color: #1895FF;
+    background-color: getShade($secondary-color, 110);
   }
 
   &[disabled],
@@ -123,14 +123,13 @@ $button-transition: all $time-s ease-in-out;
   }
 
   &:focus {
-    box-shadow: 0px 0px 14px #1895FF, 0px 0px 1px #1895FF;
+    box-shadow: 0px 0px 14px getShade($secondary-color, 110), 0px 0px 1px getShade($secondary-color, 110);
     background-color: getShade($secondary-color, 110);
     color: $white;
   }
 
   &:active {
-    // ToDo: Ask design team which color is this.
-    background-color: #1895FF;
+    background-color: getShade($secondary-color, 110);
   }
 
   &.btn--dark-background {

--- a/tests/unit/components/buttons/HdButton.spec.js
+++ b/tests/unit/components/buttons/HdButton.spec.js
@@ -1,9 +1,30 @@
+import _merge from 'lodash/merge';
 import { wrapperFactoryBuilder } from 'tests/unit/helpers';
+import InlineSvg from 'vue-inline-svg';
 import HdButton, { TYPES } from '@/components/buttons/HdButton.vue';
+
+const ICON_CONTENT = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="222 126 53 53" width="50" height="50">
+  <path class="color1" d="M272.48 137.62L258.61 150.5L244.75 141.58L254.65 126.73L272.48 137.62Z" fill="#1895FF"/>
+  <path class="color2" d="M242.22 176.24L222.97 160.68L230.47 145.1L243.56 155.68L242.22 176.24Z" fill="#1C3553"/>
+</svg>`;
+
+const stubbedInlineSvg = _merge(InlineSvg, {
+  methods: {
+    download() {
+      const parser = new DOMParser();
+      const result = parser.parseFromString(ICON_CONTENT, 'text/xml');
+      const svgEl = result.querySelector('svg');
+      return Promise.resolve(this.transformSource(svgEl));
+    },
+  },
+});
 
 const wrapperBuilder = wrapperFactoryBuilder(HdButton, {
   slots: {
     default: '<span>Button text</span>',
+  },
+  stubs: {
+    InlineSvg: stubbedInlineSvg,
   },
 });
 
@@ -27,6 +48,17 @@ describe('HdButton', () => {
       expect(wrapper.classes()).toContain(className);
       expect(wrapper.html()).toMatchSnapshot();
     });
+  });
+
+  it('should render the icon passed as prop', async () => {
+    const wrapper = wrapperBuilder({
+      props: {
+        iconSrc: 'fake/icon.svg',
+      },
+    });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('svg').exists()).toBe(true);
+    expect(wrapper.html()).toMatchSnapshot();
   });
 
   it('should forward listeners', () => {

--- a/tests/unit/components/buttons/__snapshots__/HdButton.spec.js.snap
+++ b/tests/unit/components/buttons/__snapshots__/HdButton.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HdButton should render component with \`btn\` class 1`] = `
-<button class="btn">
+<button class="btn btn--primary">
   <!----> <span>Button text</span></button>
 `;
 
@@ -28,4 +28,11 @@ exports[`HdButton should render component with btn--secondary class 1`] = `
 exports[`HdButton should render component with btn--tertiary class 1`] = `
 <button class="btn btn--tertiary">
   <!----> <span>Button text</span></button>
+`;
+
+exports[`HdButton should render the icon passed as prop 1`] = `
+<button class="btn btn--primary"><svg height="50" width="50" viewBox="222 126 53 53" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" class="btn__icon">
+    <path class="color1" d="M272.48 137.62L258.61 150.5L244.75 141.58L254.65 126.73L272.48 137.62Z" fill="#1895FF"></path>
+    <path class="color2" d="M242.22 176.24L222.97 160.68L230.47 145.1L243.56 155.68L242.22 176.24Z" fill="#1C3553"></path>
+  </svg> <span>Button text</span></button>
 `;

--- a/tests/unit/components/buttons/__snapshots__/HdButton.spec.js.snap
+++ b/tests/unit/components/buttons/__snapshots__/HdButton.spec.js.snap
@@ -8,6 +8,8 @@ exports[`HdButton should render component with btn--ghost class 1`] = `<button c
 
 exports[`HdButton should render component with btn--primary class 1`] = `<button class="btn btn--primary"><span>Button text</span></button>`;
 
+exports[`HdButton should render component with btn--quaternary class 1`] = `<button class="btn btn--quaternary"><span>Button text</span></button>`;
+
 exports[`HdButton should render component with btn--secondary class 1`] = `<button class="btn btn--secondary"><span>Button text</span></button>`;
 
 exports[`HdButton should render component with btn--tertiary class 1`] = `<button class="btn btn--tertiary"><span>Button text</span></button>`;

--- a/tests/unit/components/buttons/__snapshots__/HdButton.spec.js.snap
+++ b/tests/unit/components/buttons/__snapshots__/HdButton.spec.js.snap
@@ -1,13 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HdButton should render component with \`btn\` class 1`] = `<button class="btn"><span>Button text</span></button>`;
+exports[`HdButton should render component with \`btn\` class 1`] = `
+<button class="btn">
+  <!----> <span>Button text</span></button>
+`;
 
-exports[`HdButton should render component with btn--flat class 1`] = `<button class="btn btn--flat"><span>Button text</span></button>`;
+exports[`HdButton should render component with btn--flat class 1`] = `
+<button class="btn btn--flat">
+  <!----> <span>Button text</span></button>
+`;
 
-exports[`HdButton should render component with btn--ghost class 1`] = `<button class="btn btn--ghost"><span>Button text</span></button>`;
+exports[`HdButton should render component with btn--ghost class 1`] = `
+<button class="btn btn--ghost">
+  <!----> <span>Button text</span></button>
+`;
 
-exports[`HdButton should render component with btn--primary class 1`] = `<button class="btn btn--primary"><span>Button text</span></button>`;
+exports[`HdButton should render component with btn--primary class 1`] = `
+<button class="btn btn--primary">
+  <!----> <span>Button text</span></button>
+`;
 
-exports[`HdButton should render component with btn--secondary class 1`] = `<button class="btn btn--secondary"><span>Button text</span></button>`;
+exports[`HdButton should render component with btn--secondary class 1`] = `
+<button class="btn btn--secondary">
+  <!----> <span>Button text</span></button>
+`;
 
-exports[`HdButton should render component with btn--tertiary class 1`] = `<button class="btn btn--tertiary"><span>Button text</span></button>`;
+exports[`HdButton should render component with btn--tertiary class 1`] = `
+<button class="btn btn--tertiary">
+  <!----> <span>Button text</span></button>
+`;

--- a/tests/unit/components/buttons/__snapshots__/HdButton.spec.js.snap
+++ b/tests/unit/components/buttons/__snapshots__/HdButton.spec.js.snap
@@ -8,8 +8,6 @@ exports[`HdButton should render component with btn--ghost class 1`] = `<button c
 
 exports[`HdButton should render component with btn--primary class 1`] = `<button class="btn btn--primary"><span>Button text</span></button>`;
 
-exports[`HdButton should render component with btn--quaternary class 1`] = `<button class="btn btn--quaternary"><span>Button text</span></button>`;
-
 exports[`HdButton should render component with btn--secondary class 1`] = `<button class="btn btn--secondary"><span>Button text</span></button>`;
 
 exports[`HdButton should render component with btn--tertiary class 1`] = `<button class="btn btn--tertiary"><span>Button text</span></button>`;

--- a/tests/unit/components/form/__snapshots__/HdDynamicForm.spec.js.snap
+++ b/tests/unit/components/form/__snapshots__/HdDynamicForm.spec.js.snap
@@ -21,6 +21,7 @@ exports[`HdDynamicForm renders slots 1`] = `
     </div>
   </div>
   <div>The before button slot</div> <button class="dynamicForm__submit btn btn--primary">
+    <!---->
     submit
   </button>
   <div>The after slot</div>


### PR DESCRIPTION
This PR closes these tickets:

- https://homeday.atlassian.net/browse/CE-1541
- https://homeday.atlassian.net/browse/FET-200

## What's it about

The design team has updated the different states of HdButton, and they are already using it is some designs, which pushes us to customize the component locally as the current FE state do not match the design ones.

## What?

- Update the `HdButton` component in Blocks to match the new design specification.
- Create stories to showcase the different states of the component.
- Create tickets to replace the customized buttons with the new component.
- Create / Update Jest snapshots, if needed
- Create tests, if needed

## Design

The design and the documentation of the component can be found in [Zeroheight](https://homeday.zeroheight.com/styleguide/s/22414/p/20af8c-buttons/b/65dd3e).

## QA

The button is working as expected – check the storybook.