### PR TITLE
Release/13.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homeday-blocks",
-  "version": "12.3.1",
+  "version": "13.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homeday-blocks",
-  "version": "12.3.2",
+  "version": "13.0.0",
   "description": "A Vue component library built by Homeday's frontend team.",
   "main": "main.js",
   "repository": {

--- a/src/components/buttons/HdButton.vue
+++ b/src/components/buttons/HdButton.vue
@@ -3,13 +3,19 @@
     v-on="$listeners"
     :class="computedClasses"
   >
+    <HdIcon
+      v-if="iconSrc"
+      :src="iconSrc"
+      class="btn__icon"
+    />
     <slot />
   </button>
 </template>
 
 <script>
+import HdIcon from 'homeday-blocks/src/components/HdIcon.vue';
+
 export const TYPES = {
-  DEFAULT: '',
   PRIMARY: 'primary',
   SECONDARY: 'secondary',
   TERTIARY: 'tertiary',
@@ -19,15 +25,26 @@ export const TYPES = {
 
 export default {
   name: 'HdButton',
+  components: {
+    HdIcon,
+  },
   props: {
     modifier: {
       type: String,
-      default: TYPES.DEFAULT,
+      default: TYPES.PRIMARY,
       validator(value) {
         const allTypes = Object.values(TYPES);
 
         return allTypes.includes(value);
       },
+    },
+    isInDarkBackground: {
+      type: Boolean,
+      default: false,
+    },
+    iconSrc: {
+      type: String,
+      default: '',
     },
   },
   computed: {
@@ -39,14 +56,24 @@ export default {
         classes.push(`${baseClass}--${this.modifier}`);
       }
 
+      if (this.isInDarkBackground) {
+        classes.push(`${baseClass}--dark-background`);
+      }
+
       return classes;
     },
   },
 };
 </script>
 
-<style lang="scss" scoped>
-.btn {
-  width: 100%;
+<style lang="scss">
+@import 'homeday-blocks/src/styles/_variables.scss';
+
+.btn__icon {
+  margin-right: $inline-xs;
+
+  path {
+    fill: currentColor;
+  }
 }
 </style>

--- a/src/stories/HdButton.stories.js
+++ b/src/stories/HdButton.stories.js
@@ -1,11 +1,13 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from '@storybook/vue';
 import { action } from '@storybook/addon-actions';
-import { text, select } from '@storybook/addon-knobs';
+import { text, boolean, select } from '@storybook/addon-knobs';
 import {
   HdButton,
   HdButtonTypes as TYPES,
 } from 'homeday-blocks';
+
+import { plusIcon } from 'homeday-blocks/src/assets/small-icons';
 
 const stories = storiesOf('Components|HdButton', module);
 
@@ -38,14 +40,57 @@ stories
         type: String,
         default: select('Modifier', Object.values(TYPES), TYPES.default),
       },
+      isInDarkBackground: {
+        default: boolean('Dark background', false),
+      },
+      disabled: {
+        default: boolean('Disabled', false),
+      },
+      showIcon: {
+        default: boolean('Show icon', false),
+      },
+    },
+    data() {
+      return {
+        plusIcon,
+        styleWrapper: {
+          position: 'relative',
+          width: '100vw',
+          height: '100vh',
+          padding: '50px',
+        },
+        styleDarkBackground: {
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#1C3553',
+          zIndex: -1,
+        },
+      };
     },
     methods: {
       onClick: action('onClick'),
     },
     template: `
-      <HdButton
-        :modifier=modifier
-        @click="onClick"
-      >{{ text }}</HdButton>
+      <div :style="styleWrapper">
+        <HdButton
+          v-if="showIcon"
+          :modifier=modifier
+          :isInDarkBackground=isInDarkBackground
+          :disabled=disabled
+          @click="onClick"
+          :iconSrc=plusIcon
+        >{{ text }}</HdButton>
+        <HdButton
+          v-else
+          :modifier=modifier
+          :isInDarkBackground=isInDarkBackground
+          :disabled=disabled
+          @click="onClick"
+        >{{ text }}</HdButton>
+        <div v-if="isInDarkBackground" :style="styleDarkBackground" />
+      </div>
     `,
   }), { percy: { skip: true } });

--- a/src/styles/buttons.scss
+++ b/src/styles/buttons.scss
@@ -4,124 +4,231 @@
 $button-inset-padding: 16px;
 $button-transition: all $time-s ease-in-out;
 
+@mixin btn-ripple($ripple-color: $white, $blend-mode: normal, $opacity: 0.2) {
+  position: relative;
+  overflow: hidden;
+  transform: translate3d(0, 0, 0);
+
+  &::after {
+    content: "";
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    background-image: radial-gradient(circle, $ripple-color 10%, transparent 10.01%);
+    background-repeat: no-repeat;
+    background-position: 50%;
+    mix-blend-mode: $blend-mode;
+    transform: scale(10, 10);
+    opacity: 0;
+    transition: transform 0.3s, opacity 0.8s;
+  }
+
+  &:active {
+    &::after {
+      transform: scale(0, 0);
+      opacity: $opacity;
+      transition: 0s;
+    }
+  }
+}
+
 .btn {
-  @include font('body');
+  box-sizing: border-box;
   display: inline-flex;
-  text-decoration: none;
-  border: none;
-  border-radius: $default-border-radius;
-  background-color: transparent;
-  padding: 13px $stack-m;
-  justify-content: center;
-  width: auto;
   align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: $stack-s $inline-l;
+  border: 0;
+  border-radius: 2px;
+  outline: 0;
+  background-color: transparent;
+  font-family: $font-primary;
   font-weight: 600;
+  font-size: 16px;
+  line-height: 28px;
   text-align: center;
+  text-decoration: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+
   &:hover {
     cursor: pointer;
   }
 }
 
-.btn--primary,
-.btn--secondary {
+.btn--primary {
+  @include btn-ripple;
+
   background-color: getShade($secondary-color, 110);
+  box-shadow: 0px 3px 2px rgba(0, 0, 0, 0.12), 0px 0px 4px rgba(0, 0, 0, 0.24);
   color: $white;
-  font-family: $font-primary;
-  width: 100%;
-  font-size: 16px;
-  height: 52px;
-  padding: 0 $stack-m;
-  box-shadow: 0 2px 2px 0 rgba(0,0,0,0.3);
-  transition: $button-transition;
+  transition: 
+    background-color 0.3s ease-in-out,
+    box-shadow 0.3s ease-in-out,
+    color 0.3s ease-in-out;
+
   &:hover {
-    color: $white;
-    box-shadow: 0 3px 2px 0 rgba(0,0,0,0.3);
+    box-shadow: 0px 6px 12px rgba(0, 0, 0, 0.3);
+  }
+
+  &:focus {
+    box-shadow: 0px 0px 14px getShade($secondary-color, 110), 0px 0px 1px getShade($secondary-color, 110);
+  }
+
+  &:active {
     background-color: getShade($secondary-color, 110);
-    transform: translateY(-1px);
-  }
-  
-  // Ripple effect on click
-  position: relative;
-  overflow: hidden;
-  transform: translate3d(0,0,0);
-  &:after {
-    content: "";
-    display: block;
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    top: 0;
-    left: 0;
-    pointer-events: none;
-    background-image: radial-gradient(circle,#000 10%,transparent 10.01%);
-    background-repeat: no-repeat;
-    background-position: 50%;
-    transform: scale(10,10);
-    opacity: 0;
-    transition: transform 300ms, opacity 0.8s;
-
-  }
-  &:active:after {
-    transform: scale(0,0);
-    opacity: .2;
-    transition: 0s;
   }
 
-  @media (min-width: $break-tablet) {
-    font-size: 18px;
-    width: auto;
+  &[disabled],
+  &.btn--disabled {
+    background: getShade($neutral-gray, 50);
+    box-shadow: none;
+    color: getShade($neutral-gray, 90);
+
+    &:after {
+      display: none;
+    }
+
+    &:hover,
+    &:active,
+    &:focus {
+      background-color: getShade($neutral-gray, 50);
+      cursor: default;
+      box-shadow: none;
+      transform: none;
+    }
   }
 }
 
-.btn--primary[disabled],
-.btn--primary-disabled {
-  background-color: getShade($neutral-gray, 60);
-  color: $white;
-  box-shadow: 0 0 2px 0 rgba(0,0,0,0.12), 0 2px 2px 0 rgba(0,0,0,0.24);
-  &:after {
-    display: none;
+.btn--secondary {
+  @include btn-ripple;
+
+  padding: #{$stack-s - 2px} #{$inline-l - 2px}; // adjustment for the border-width of 2px
+  border: 2px solid getShade($secondary-color, 110);
+  color: getShade($secondary-color, 110);
+  transition: 
+    background-color 0.3s ease-in-out,
+    border 0.3s ease-in-out,
+    box-shadow 0.3s ease-in-out,
+    color 0.3s ease-in-out;
+
+  &:hover {
+    box-shadow: 0px 6px 12px rgba(0, 0, 0, 0.3);
+    background-color: getShade($secondary-color, 110);
+    color: $white;
   }
-  &:hover, &:active, &:focus, &:active:focus {
-    background-color: getShade($neutral-gray, 60);
-    cursor: not-allowed;
+
+  &:focus {
+    box-shadow: 0px 0px 14px getShade($secondary-color, 110), 0px 0px 1px getShade($secondary-color, 110);
+    background-color: getShade($secondary-color, 110);
+    color: $white;
+  }
+
+  &:active {
+    background-color: getShade($secondary-color, 110);
+  }
+
+  &.btn--dark-background {
+    border: 2px solid $white;
+    color: $white;
+
+    &:hover,
+    &:focus {
+      border: 2px solid getShade($secondary-color, 110);
+    }
+  }
+
+  &[disabled],
+  &.btn--disabled {
+    border: 2px solid getShade($neutral-gray, 60);
+    color: getShade($neutral-gray, 70);
     box-shadow: none;
-    transform: none;
+
+    &:after {
+      display: none;
+    }
+
+    &:hover,
+    &:active,
+    &:focus {
+      background-color: transparent;
+      cursor: default;
+      box-shadow: none;
+      transform: none;
+    }
+
+    &.btn--dark-background {
+      color: getShade($neutral-gray, 60);
+    }
   }
 }
 
 .btn--tertiary {
-  @include font('body');
-  display: inline-block;
-  color: getShade($secondary-color, 110);
-  transition: $button-transition;
-  font-weight: 600;
-  position: relative;
-  width: auto;
+  @include btn-ripple(getShade($secondary-color, 80), multiply, 0.4);
 
-  &:after {
-    content: "";
-    width: calc(100% - #{2 * $button-inset-padding});
-    height: 2px;
-    background-color: getShade($secondary-color, 110);
-    position: absolute;
-    bottom: 12px;
-    left: 0;
-    right: 0;
-    margin: auto;
+  padding: #{$stack-s - 2px} #{$inline-l - 2px}; // adjustment for the border-width of 2px
+  border: 2px solid transparent;
+  background-color: getShade($secondary-color, 70);
+  color: getShade($secondary-color, 110);
+  transition: 
+    background-color 0.3s ease-in-out,
+    border 0.3s ease-in-out,
+    padding 0.3s ease-in-out;
+
+  &:hover {
+    background-color: transparent;
+    border: 2px solid getShade($secondary-color, 110);
   }
-  &:before {
-    content: "";
-    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMCA1Ij48ZyBpZD0iSG9tZXBhZ2UiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgaWQ9ImhvbWVwYWdlXzMuMC5fUHJpbWFyeV9OYXZpZ2F0aW9uX0V4cGFuZGVkIiBmaWxsPSIjMTg5NUZGIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMTMwMC4wMDAwMDAsIC00OS4wMDAwMDApIj48ZyBpZD0iTW9sZWN1bGVzL2hlYWRlciIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTEuMDAwMDAwLCAwLjAwMDAwMCkiPjxnIGlkPSJOYXZpZ2F0aW9uLS1wcmltYXJ5IiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxLjAwMDAwMCwgMC4wMDAwMDApIj48ZyBpZD0iQ29udGVudCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTQ0LjAwMDAwMCwgMTYuMDAwMDAwKSI+PGcgaWQ9ImF0b20vaWNvbi9pY19tZW51YXJyb3ctZG93bi1ibHVlIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxMTU2LjAwMDAwMCwgMzMuMDAwMDAwKSI+PHBvbHlnb24gaWQ9ImljX21lbnVhcnJvdy1kb3duLWJsdWUiIHBvaW50cz0iMi4wODMzMzMzMyA2LjI4MTgwMTM0IDUuNTgyMTc2MTMgMi41IDIuMDgzMzMzMzMgLTEuMjgxODAxMzQgMi44NDMzNDc1OCAtMi4wODMzMzMzMyA3LjA4MzMzMzMzIDIuNSAyLjg0MzM0NzU4IDcuMDgzMzMzMzMiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDQuNTgzMzMzLCAyLjUwMDAwMCkgc2NhbGUoMSwgLTEpIHJvdGF0ZSgtOTAuMDAwMDAwKSB0cmFuc2xhdGUoLTQuNTgzMzMzLCAtMi41MDAwMDApICIvPjwvZz48L2c+PC9nPjwvZz48L2c+PC9nPjwvc3ZnPg==);    
-    background-repeat: no-repeat;
-    height: 10px;
-    width: 15px;
-    display: block;
-    position: absolute;
-    right: -4px;
-    bottom: 20px;
+
+  &:focus {
+    background-color: transparent;
+    border: 2px solid getShade($secondary-color, 110);
   }
-  &:hover:before {
-    animation: bounceBack 500ms normal ease-in-out;
+
+  &:active {
+    background-color: getShade($secondary-color, 70);
+    border: 2px solid transparent;
+  }
+
+  &.btn--dark-background {
+    background-color: rgba(white, 0.2);
+    color: white;
+
+    &:hover,
+    &:focus {
+      border: 2px solid white;
+    }
+  }
+
+  &[disabled],
+  &.btn--disabled {
+    background-color: getShade($neutral-gray, 40);
+    border: 2px solid transparent;
+    color: getShade($neutral-gray, 70);
+    box-shadow: none;
+
+    &:after {
+      display: none;
+    }
+
+    &:hover,
+    &:active,
+    &:focus {
+      background-color: getShade($neutral-gray, 40);
+      border: 2px solid transparent;
+      cursor: default;
+      box-shadow: none;
+      transform: none;
+    }
+
+    &.btn--dark-background {
+      background-color: rgba(120, 143, 171, 0.7);
+    }
   }
 }
 

--- a/tests/unit/components/buttons/HdButton.spec.js
+++ b/tests/unit/components/buttons/HdButton.spec.js
@@ -1,9 +1,30 @@
+import _merge from 'lodash/merge';
 import { wrapperFactoryBuilder } from 'tests/unit/helpers';
+import InlineSvg from 'vue-inline-svg';
 import HdButton, { TYPES } from '@/components/buttons/HdButton.vue';
+
+const ICON_CONTENT = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="222 126 53 53" width="50" height="50">
+  <path class="color1" d="M272.48 137.62L258.61 150.5L244.75 141.58L254.65 126.73L272.48 137.62Z" fill="#1895FF"/>
+  <path class="color2" d="M242.22 176.24L222.97 160.68L230.47 145.1L243.56 155.68L242.22 176.24Z" fill="#1C3553"/>
+</svg>`;
+
+const stubbedInlineSvg = _merge(InlineSvg, {
+  methods: {
+    download() {
+      const parser = new DOMParser();
+      const result = parser.parseFromString(ICON_CONTENT, 'text/xml');
+      const svgEl = result.querySelector('svg');
+      return Promise.resolve(this.transformSource(svgEl));
+    },
+  },
+});
 
 const wrapperBuilder = wrapperFactoryBuilder(HdButton, {
   slots: {
     default: '<span>Button text</span>',
+  },
+  stubs: {
+    InlineSvg: stubbedInlineSvg,
   },
 });
 
@@ -27,6 +48,17 @@ describe('HdButton', () => {
       expect(wrapper.classes()).toContain(className);
       expect(wrapper.html()).toMatchSnapshot();
     });
+  });
+
+  it('should render the icon passed as prop', async () => {
+    const wrapper = wrapperBuilder({
+      props: {
+        iconSrc: 'fake/icon.svg',
+      },
+    });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('svg').exists()).toBe(true);
+    expect(wrapper.html()).toMatchSnapshot();
   });
 
   it('should forward listeners', () => {

--- a/tests/unit/components/buttons/HdButton.spec.js
+++ b/tests/unit/components/buttons/HdButton.spec.js
@@ -50,6 +50,18 @@ describe('HdButton', () => {
     });
   });
 
+  it('should render component with btn--dark-background class if prop isInDarkBackground is true', () => {
+    const className = 'btn--dark-background';
+    const wrapper = wrapperBuilder({
+      props: {
+        isInDarkBackground: true,
+      },
+    });
+
+    expect(wrapper.classes()).toContain(className);
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
   it('should render the icon passed as prop', async () => {
     const wrapper = wrapperBuilder({
       props: {

--- a/tests/unit/components/buttons/__snapshots__/HdButton.spec.js.snap
+++ b/tests/unit/components/buttons/__snapshots__/HdButton.spec.js.snap
@@ -1,13 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HdButton should render component with \`btn\` class 1`] = `<button class="btn"><span>Button text</span></button>`;
+exports[`HdButton should render component with \`btn\` class 1`] = `
+<button class="btn btn--primary">
+  <!----> <span>Button text</span></button>
+`;
 
-exports[`HdButton should render component with btn--flat class 1`] = `<button class="btn btn--flat"><span>Button text</span></button>`;
+exports[`HdButton should render component with btn--flat class 1`] = `
+<button class="btn btn--flat">
+  <!----> <span>Button text</span></button>
+`;
 
-exports[`HdButton should render component with btn--ghost class 1`] = `<button class="btn btn--ghost"><span>Button text</span></button>`;
+exports[`HdButton should render component with btn--ghost class 1`] = `
+<button class="btn btn--ghost">
+  <!----> <span>Button text</span></button>
+`;
 
-exports[`HdButton should render component with btn--primary class 1`] = `<button class="btn btn--primary"><span>Button text</span></button>`;
+exports[`HdButton should render component with btn--primary class 1`] = `
+<button class="btn btn--primary">
+  <!----> <span>Button text</span></button>
+`;
 
-exports[`HdButton should render component with btn--secondary class 1`] = `<button class="btn btn--secondary"><span>Button text</span></button>`;
+exports[`HdButton should render component with btn--secondary class 1`] = `
+<button class="btn btn--secondary">
+  <!----> <span>Button text</span></button>
+`;
 
-exports[`HdButton should render component with btn--tertiary class 1`] = `<button class="btn btn--tertiary"><span>Button text</span></button>`;
+exports[`HdButton should render component with btn--tertiary class 1`] = `
+<button class="btn btn--tertiary">
+  <!----> <span>Button text</span></button>
+`;
+
+exports[`HdButton should render the icon passed as prop 1`] = `
+<button class="btn btn--primary"><svg height="50" width="50" viewBox="222 126 53 53" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" class="btn__icon">
+    <path class="color1" d="M272.48 137.62L258.61 150.5L244.75 141.58L254.65 126.73L272.48 137.62Z" fill="#1895FF"></path>
+    <path class="color2" d="M242.22 176.24L222.97 160.68L230.47 145.1L243.56 155.68L242.22 176.24Z" fill="#1C3553"></path>
+  </svg> <span>Button text</span></button>
+`;

--- a/tests/unit/components/buttons/__snapshots__/HdButton.spec.js.snap
+++ b/tests/unit/components/buttons/__snapshots__/HdButton.spec.js.snap
@@ -5,6 +5,11 @@ exports[`HdButton should render component with \`btn\` class 1`] = `
   <!----> <span>Button text</span></button>
 `;
 
+exports[`HdButton should render component with btn--dark-background class if prop isInDarkBackground is true 1`] = `
+<button class="btn btn--primary btn--dark-background">
+  <!----> <span>Button text</span></button>
+`;
+
 exports[`HdButton should render component with btn--flat class 1`] = `
 <button class="btn btn--flat">
   <!----> <span>Button text</span></button>

--- a/tests/unit/components/form/__snapshots__/HdDynamicForm.spec.js.snap
+++ b/tests/unit/components/form/__snapshots__/HdDynamicForm.spec.js.snap
@@ -21,6 +21,7 @@ exports[`HdDynamicForm renders slots 1`] = `
     </div>
   </div>
   <div>The before button slot</div> <button class="dynamicForm__submit btn btn--primary">
+    <!---->
     submit
   </button>
   <div>The after slot</div>


### PR DESCRIPTION
# Changelog

## Features
- Update styles for `HdButton` (#489)

## Breaking changes

| Button type | Version 12.3.2  | Version 13.0.0 |
| ------------- | ------------- | ------------- |
| Default | <img width="494" alt="Screen Shot 2020-08-20 at 17 21 15" src="https://user-images.githubusercontent.com/7268262/90831758-0ddd3380-e30a-11ea-8fef-1fe5f1bc832d.png"> | ❌ **removed** |
| Primary | <img width="495" alt="Screen Shot 2020-08-20 at 17 21 23" src="https://user-images.githubusercontent.com/7268262/90831819-26e5e480-e30a-11ea-83e0-f676b2d70f50.png"> | <img width="137" alt="Screen Shot 2020-08-20 at 17 33 43" src="https://user-images.githubusercontent.com/7268262/90832435-5f39f280-e30b-11ea-8274-0e4c30b4bed0.png"> |
| Secondary | <img width="497" alt="Screen Shot 2020-08-20 at 17 21 31" src="https://user-images.githubusercontent.com/7268262/90831921-57c61980-e30a-11ea-92b8-32dd95aed43e.png"> | <img width="158" alt="Screen Shot 2020-08-20 at 17 33 49" src="https://user-images.githubusercontent.com/7268262/90832443-65c86a00-e30b-11ea-81f2-af6267a2b4a2.png"> |
| Tertiary | <img width="497" alt="Screen Shot 2020-08-20 at 17 21 37" src="https://user-images.githubusercontent.com/7268262/90831942-6280ae80-e30a-11ea-8d1f-ccc53a4a3cbf.png"> |  <img width="145" alt="Screen Shot 2020-08-20 at 17 33 55" src="https://user-images.githubusercontent.com/7268262/90832460-6fea6880-e30b-11ea-9354-144e78f2f3f9.png"> |

## Other changes:

- Removed `width: 100%;`.
- Added padding specified in the design system.
- Added dark-background styles.
- Added icon support.


