### PR TITLE
[T] Test Gallery components

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "babel-loader": "^8.1.0",
     "core-js": "3.6.4",
     "coveralls": "^3.0.7",
+    "deepmerge": "^4.2.2",
     "dotenv": "^8.2.0",
     "eslint": "^6.5.1",
     "eslint-plugin-vue": "5.2.3",

--- a/src/components/gallery/HdGallery.vue
+++ b/src/components/gallery/HdGallery.vue
@@ -1,9 +1,9 @@
 <template>
   <div
-    :class="{
-      hasSingleItem,
-    }"
     class="gallery"
+    :class="{
+      'gallery--has-single-item': hasSingleItem,
+    }"
   >
     <figure
       v-if="hasImages"
@@ -292,7 +292,7 @@ export default {
   }
 
   &__carousel {
-    #{$_root}.hasSingleItem & {
+    #{$_root}--has-single-item & {
       @media (min-width: $break-tablet) {
         display: none;
       }

--- a/src/components/gallery/HdGallery.vue
+++ b/src/components/gallery/HdGallery.vue
@@ -27,8 +27,8 @@
           class="gallery__controls"
         >
           <button
+            class="gallery__controls-prev"
             :class="{
-              'gallery__controls__prev': true,
               'isDisabled': isFirstItem,
             }"
             type="button"
@@ -40,8 +40,8 @@
             />
           </button>
           <button
+            class="gallery__controls-next"
             :class="{
-              'gallery__controls__next': true,
               'isDisabled': isLastItem,
             }"
             type="button"
@@ -236,8 +236,8 @@ export default {
       display: block;
     }
 
-    &__prev,
-    &__next {
+    &-prev,
+    &-next {
       display: flex;
       width: 36px;
       height: 36px;
@@ -267,7 +267,7 @@ export default {
       }
     }
 
-    &__next {
+    &-next {
       left: auto;
       right: 0;
       transform: translate(30%, -50%);

--- a/src/components/gallery/HdGalleryCarousel.vue
+++ b/src/components/gallery/HdGalleryCarousel.vue
@@ -1,39 +1,32 @@
 <template>
   <div
+    class="gallery-carousel"
     :class="{
-      'gallery-carousel': true,
-      isUsingMouse,
-      withPagerInside: pagerInside,
+      'gallery-carousel--with-pager-inside': pagerInside,
     }"
-    @keydown="setUsingMouse(false)"
-    @mousedown="setUsingMouse(true)"
   >
     <div
       class="gallery-carousel__wrap"
       tabindex="0"
       @keydown.self="maybeSelectItem"
-      @blur.self="setUsingMouse(false)"
     >
       <flickity
         ref="flickity"
         :options="flickityOptions"
       >
         <div
+          class="gallery-carousel__item"
           v-for="(item, i) in items"
           :key="i"
           :class="{
-            'gallery-carousel__item': true,
-            'isActive': shouldShowActiveState(i),
+            'is-active': shouldShowActiveState(i),
           } "
         >
-          <div
-            :style="sizerStyles"
-            class="gallery-carousel__item__sizer"
-          />
+          <div :style="sizerStyles" />
 
           <!-- the item.thumbnail field is used as default value for the item image -->
           <!-- IE11 uses this value only because do not support the picture element -->
-          <picture class="gallery-carousel__item__picture">
+          <picture class="gallery-carousel__item-picture">
               <source v-for="(source, media) in item.thumbnailPictureSources"
                 :key="media"
                 :media="`(${media})`" :srcset="source"
@@ -100,7 +93,6 @@ export default {
       currentIndex: 0,
       pagerItemsCount: 0,
       valueChanged: false,
-      isUsingMouse: false,
     };
   },
   computed: {
@@ -216,9 +208,6 @@ export default {
 
       this.$refs.flickity.select(targetSlide);
     },
-    setUsingMouse(usingMouse) {
-      this.isUsingMouse = usingMouse;
-    },
   },
 };
 </script>
@@ -229,10 +218,6 @@ export default {
 .gallery-carousel {
   $_root: &;
   position: relative;
-
-  &.isUsingMouse * {
-    outline: 0;
-  }
 
   &__wrap {
     overflow: hidden;
@@ -251,7 +236,7 @@ export default {
       margin-top: $stack-m;
     }
 
-    #{$_root}.withPagerInside & {
+    #{$_root}--with-pager-inside & {
       position: absolute;
       bottom: 0px;
       width: 100%;
@@ -283,7 +268,7 @@ export default {
 
       &:hover,
       &:focus,
-      &.isActive {
+      &.is-active {
         box-shadow: 0 5px 7px -3px rgba(0, 0, 0, 0.5);
         @media (min-width: $break-tablet) {
           box-shadow: 0 6px 11px -3px rgba(0, 0, 0, 0.45);
@@ -302,7 +287,7 @@ export default {
       object-fit: cover;
     }
 
-    &__picture {
+    &-picture {
       position: absolute;
       top: 0;
       right: 0;

--- a/src/components/gallery/HdGalleryCarousel.vue
+++ b/src/components/gallery/HdGalleryCarousel.vue
@@ -26,7 +26,7 @@
 
           <!-- the item.thumbnail field is used as default value for the item image -->
           <!-- IE11 uses this value only because do not support the picture element -->
-          <picture class="gallery-carousel__item-picture">
+          <picture class="gallery-carousel__picture">
               <source v-for="(source, media) in item.thumbnailPictureSources"
                 :key="media"
                 :media="`(${media})`" :srcset="source"
@@ -213,7 +213,7 @@ export default {
 </script>
 
 <style lang="scss">
-@import 'homeday-blocks/src/styles/mixins.scss';
+@import "homeday-blocks/src/styles/mixins.scss";
 
 .gallery-carousel {
   $_root: &;
@@ -280,14 +280,9 @@ export default {
       width: calc(100% / 7);
       margin-right: $inline-m;
     }
-
-    img {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
     }
 
-    &-picture {
+  &__picture {
       position: absolute;
       top: 0;
       right: 0;
@@ -297,6 +292,11 @@ export default {
       align-items: center;
       justify-content: center;
       z-index: 1;
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
     }
   }
 }

--- a/src/components/gallery/HdGalleryMedia.vue
+++ b/src/components/gallery/HdGalleryMedia.vue
@@ -1,9 +1,7 @@
 <template>
   <div class="gallery-media">
     <div class="gallery-media__object">
-      <div
-        :style="sizerStyles"
-        class="gallery-media__object__sizer"/>
+      <div :style="sizerStyles" />
 
       <!-- the item.image field is used as default value for the item image -->
       <!-- IE11 uses this value only because do not support the picture element -->

--- a/src/components/gallery/HdGalleryMedia.vue
+++ b/src/components/gallery/HdGalleryMedia.vue
@@ -60,10 +60,12 @@ export default {
     },
   },
   watch: {
-    item() {
-      this.$nextTick(() => {
-        this.showThumbnail = true;
-      });
+    item(oldValue, newValue) {
+      if (oldValue.image !== newValue.image) {
+        this.$nextTick(() => {
+          this.showThumbnail = true;
+        });
+      }
     },
   },
   methods: {

--- a/src/components/gallery/HdGalleryMedia.vue
+++ b/src/components/gallery/HdGalleryMedia.vue
@@ -5,7 +5,7 @@
 
       <!-- the item.image field is used as default value for the item image -->
       <!-- IE11 uses this value only because do not support the picture element -->
-      <picture class="gallery-media__object__picture">
+      <picture class="gallery-media__object-picture">
         <source v-for="(source, media) in item.pictureSources"
                 :key="media"
                 :media="`(${media})`" :srcset="source"
@@ -15,13 +15,9 @@
 
       <div
         v-if="hasThumbnail"
-        :class="{
-          'gallery-media__object__thumbnail': true,
-          'isVisible': showThumbnail,
-        }"
-        :style="{
-          'background-image': `url('${item.thumbnail}')`,
-        }"
+        class="gallery-media__object-thumbnail"
+        :class="{ 'isVisible': showThumbnail }"
+        :style="{ 'background-image': `url('${item.thumbnail}')` }"
       />
     </div>
   </div>
@@ -86,8 +82,8 @@ export default {
     background-color: $secondary-bg;
     cursor: pointer;
 
-    &__thumbnail,
-    &__picture {
+    &-thumbnail,
+    &-picture {
       position: absolute;
       top: 0;
       right: 0;
@@ -96,35 +92,33 @@ export default {
       z-index: 1;
     }
 
-    &__picture {
+    &-picture {
       display: flex;
       align-items: center;
       justify-content: center;
     }
 
-    &__thumbnail {
+    &-thumbnail {
+      opacity: 0;
+      transition: opacity ($time-s * 2) ease-in-out;
+      filter: blur(3px);
       background-position: center;
       background-repeat: no-repeat;
       background-size: contain;
+
       @media (min-width: $break-tablet) {
         background-size: cover;
+      }
+
+      &.isVisible {
+        opacity: 1;
+        transition: none;
       }
     }
 
     img {
       max-width: 100%;
       max-height: 100%;
-    }
-
-    &__thumbnail {
-      opacity: 0;
-      transition: opacity ($time-s * 2) ease-in-out;
-      filter: blur(3px);
-
-      &.isVisible {
-        opacity: 1;
-        transition: none;
-      }
     }
   }
 }

--- a/src/components/gallery/HdGalleryMedia.vue
+++ b/src/components/gallery/HdGalleryMedia.vue
@@ -6,11 +6,19 @@
       <!-- the item.image field is used as default value for the item image -->
       <!-- IE11 uses this value only because do not support the picture element -->
       <picture class="gallery-media__object-picture">
-        <source v-for="(source, media) in item.pictureSources"
-                :key="media"
-                :media="`(${media})`" :srcset="source"
-        >
-        <img ref="imageHolder" :src="item.image" :alt="item.caption" :srcset="item.imageSrcSet" @load="hideThumbnail"/>
+        <source
+          v-for="(source, media) in item.pictureSources"
+          :key="media"
+          :media="`(${media})`"
+          :srcset="source"
+        />
+        <img
+          ref="imageHolder"
+          :src="item.image"
+          :alt="item.caption"
+          :srcset="item.imageSrcSet"
+          @load="hideThumbnail"
+        />
       </picture>
 
       <div

--- a/src/components/gallery/HdGalleryPlaceholder.vue
+++ b/src/components/gallery/HdGalleryPlaceholder.vue
@@ -7,9 +7,9 @@
     <div class="gallery-placeholder__content">
       <img
         :src="icon"
-        class="gallery-placeholder__content__icon"
+        class="gallery-placeholder__content-icon"
       >
-      <p class="gallery-placeholder__content__text">
+      <p class="gallery-placeholder__content-text">
         {{ text }}
       </p>
     </div>
@@ -60,13 +60,13 @@ export default {
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    &__icon {
+    &-icon {
       height: 100px;
       @media (min-width: $break-tablet) {
         height: 155px;
       }
     }
-    &__text {
+    &-text {
       margin-top: $stack-xs;
       @media (min-width: $break-tablet) {
         margin-top: $stack-l;

--- a/src/stories/HdGallery.stories.js
+++ b/src/stories/HdGallery.stories.js
@@ -44,6 +44,7 @@ export default {
     pagerInside: false,
     disableKeyEvents: false,
     showCaption: true,
+    startIndex: 0,
   },
   parameters: { percy: { widths: [375] } },
 };

--- a/tests/unit/components/gallery/HDGallery.spec.js
+++ b/tests/unit/components/gallery/HDGallery.spec.js
@@ -3,13 +3,15 @@ import HdGallery from '@/components/gallery/HdGallery.vue';
 import HdGalleryPlaceholder from '@/components/gallery/HdGalleryPlaceholder.vue';
 import ITEMS from '@/stories/mocks/GALLERY_ITEMS';
 
+const wrapperFactory = wrapperFactoryBuilder(HdGallery, {
+  props: {
+    items: ITEMS,
+  },
+});
+
 describe('HdGallery', () => {
   const build = (props) => {
-    const wrapper = wrapperFactoryBuilder(HdGallery, {
-      props: {
-        items: ITEMS,
-      },
-    })({ props });
+    const wrapper = wrapperFactory({ props });
 
     return {
       wrapper,

--- a/tests/unit/components/gallery/HDGallery.spec.js
+++ b/tests/unit/components/gallery/HDGallery.spec.js
@@ -1,33 +1,112 @@
+import _ from 'lodash';
 import { wrapperFactoryBuilder } from 'tests/unit/helpers';
 import HdGallery from '@/components/gallery/HdGallery.vue';
+import HdGalleryPlaceholder from '@/components/gallery/HdGalleryPlaceholder.vue';
 import ITEMS from '@/stories/mocks/GALLERY_ITEMS';
 
-const IMAGE_SELECTOR = '.gallery__image';
+describe('HdGalleryCarousel', () => {
+  const build = (props = {}) => {
+    const wrapper = wrapperFactoryBuilder(HdGallery, {
+      props: _.assign({
+        items: ITEMS,
+      }, props),
+    })();
 
-const wrapperBuilder = wrapperFactoryBuilder(HdGallery, {
-  props: {
-    items: ITEMS,
-  },
-});
+    return {
+      wrapper,
+      caption: () => wrapper.find('.gallery__caption'),
+      nextButton: () => wrapper.find('.gallery__controls-next'),
+      previousButton: () => wrapper.find('.gallery__controls-prev'),
+      selectedPicture: () => wrapper.find('.gallery-media__object-picture'),
+      selectedPictureImg: () => wrapper.find('.gallery-media__object-picture').find('img'),
+      selectedPictureInfo: () => wrapper.find('.gallery__info'),
+      carousel: () => wrapper.findAll('.gallery__carousel'),
+      carouselWrap: () => wrapper.findAll('.gallery-carousel__wrap'),
+      flickity: () => wrapper.find('.gallery-carousel').find({ ref: 'flickity' }),
+      placeholder: () => wrapper.find(HdGalleryPlaceholder),
+    };
+  };
 
-describe('HdGallery', () => {
-  it('renders component', () => {
-    const wrapper = wrapperBuilder();
-
+  it('renders the component', () => {
+    const { wrapper } = build();
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it('switchs elements and emits the proper events clicks', () => {
-    const wrapper = wrapperBuilder();
-    const testIndex = 3;
-    const image = wrapper.find(IMAGE_SELECTOR);
+  test('a user can navigate through the gallery', async () => {
+    const items = ITEMS;
+    const {
+      placeholder,
+      caption,
+      nextButton,
+      previousButton,
+      selectedPictureImg,
+      carouselWrap,
+      selectedPictureInfo,
+    } = build({ items });
 
-    image.trigger('click');
-    expect(wrapper.emitted('currentItemClick')[0][0]).toBe(0);
+    function assetPictureIsSelected(index) {
+      expect(caption().text()).toContain(items[index].caption);
+      expect(selectedPictureImg().attributes().src).toEqual(items[index].image);
+      expect(selectedPictureImg().attributes().alt).toEqual(items[index].caption);
+      expect(selectedPictureInfo().text()).toContain(`${index + 1}/${items.length}`);
+    }
 
-    wrapper.setData({ currentItemIndex: testIndex });
+    expect(placeholder().exists()).toBe(false);
+    assetPictureIsSelected(0);
 
-    image.trigger('click');
-    expect(wrapper.emitted('currentItemClick')[1][0]).toBe(testIndex);
+    await nextButton().trigger('click');
+    assetPictureIsSelected(1);
+
+    await carouselWrap().trigger('keydown', { key: 'ArrowRight' });
+    assetPictureIsSelected(2);
+
+    await carouselWrap().trigger('keydown', { key: 'ArrowDown' });
+    assetPictureIsSelected(3);
+
+    await carouselWrap().trigger('keydown', { key: 'ArrowLeft' });
+    assetPictureIsSelected(2);
+
+    await carouselWrap().trigger('keydown', { key: 'ArrowUp' });
+    assetPictureIsSelected(1);
+
+    await previousButton().trigger('click');
+    assetPictureIsSelected(0);
+  });
+
+  it('displays a placeholder', () => {
+    const expectedPlaceholderText = 'Little Stranger - Styles & Dynamics';
+    const expectedPlaceholderIcon = 'static/media/ic_pictures.b82fd409.svg';
+    const {
+      placeholder,
+      caption,
+      selectedPicture,
+      carouselWrap,
+    } = build({
+      items: [],
+      placeholderText: expectedPlaceholderText,
+      placeholderIcon: expectedPlaceholderIcon,
+    });
+
+    expect(caption().exists()).toBe(false);
+    expect(selectedPicture().exists()).toBe(false);
+    expect(carouselWrap().exists()).toBe(false);
+
+    expect(placeholder().exists()).toBe(true);
+    expect(placeholder().text()).toContain(expectedPlaceholderText);
+    expect(placeholder().find('img').attributes().src).toBe(expectedPlaceholderIcon);
+  });
+
+  it('hides picture captions', () => {
+    const { caption } = build({ showCaption: false });
+    expect(caption().exists()).toBe(false);
+  });
+
+  it('starts the gallery at specific index', () => {
+    const items = ITEMS;
+    const expectedIndex = 2;
+    const { selectedPictureImg } = build({ items, startIndex: expectedIndex });
+
+    expect(selectedPictureImg().attributes().src).toEqual(items[expectedIndex].image);
+    expect(selectedPictureImg().attributes().alt).toEqual(items[expectedIndex].caption);
   });
 });

--- a/tests/unit/components/gallery/HDGallery.spec.js
+++ b/tests/unit/components/gallery/HDGallery.spec.js
@@ -1,16 +1,15 @@
-import _ from 'lodash';
 import { wrapperFactoryBuilder } from 'tests/unit/helpers';
 import HdGallery from '@/components/gallery/HdGallery.vue';
 import HdGalleryPlaceholder from '@/components/gallery/HdGalleryPlaceholder.vue';
 import ITEMS from '@/stories/mocks/GALLERY_ITEMS';
 
-describe('HdGalleryCarousel', () => {
-  const build = (props = {}) => {
+describe('HdGallery', () => {
+  const build = (props) => {
     const wrapper = wrapperFactoryBuilder(HdGallery, {
-      props: _.assign({
+      props: {
         items: ITEMS,
-      }, props),
-    })();
+      },
+    })({ props });
 
     return {
       wrapper,

--- a/tests/unit/components/gallery/HDGalleryMedia.spec.js
+++ b/tests/unit/components/gallery/HDGalleryMedia.spec.js
@@ -1,17 +1,43 @@
+import _ from 'lodash';
 import { wrapperFactoryBuilder } from 'tests/unit/helpers';
 import HdGalleryMedia from '@/components/gallery/HdGalleryMedia.vue';
 import ITEMS from '@/stories/mocks/GALLERY_ITEMS';
 
-const wrapperBuilder = wrapperFactoryBuilder(HdGalleryMedia, {
-  props: {
-    item: ITEMS[0],
-  },
-});
-
 describe('HdGalleryMedia', () => {
-  it('renders component', () => {
-    const wrapper = wrapperBuilder();
+  const build = (props = {}) => {
+    const wrapper = wrapperFactoryBuilder(HdGalleryMedia, {
+      props: _.merge({
+        item: ITEMS[0],
+      }, props),
+    })();
 
+    return {
+      wrapper,
+      img: () => wrapper.find('img'),
+      thumbnail: () => wrapper.find('.gallery-media__object-thumbnail'),
+    };
+  };
+
+  it('renders component', () => {
+    const { wrapper } = build();
     expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('hides the thumbnail when the image is loaded', async () => {
+    const { wrapper, img, thumbnail } = build();
+
+    expect(thumbnail().classes()).toContain('isVisible');
+
+    img().trigger('load');
+    await wrapper.vm.$nextTick();
+
+    expect(thumbnail().classes()).not.toContain('isVisible');
+  });
+
+  it('hides the thumbnail when is not provided', async () => {
+    const itemWithoutThumb = { ...ITEMS[0], thumbnail: null };
+    const { thumbnail } = build({ item: itemWithoutThumb });
+
+    expect(thumbnail().exists()).toBe(false);
   });
 });

--- a/tests/unit/components/gallery/HDGalleryMedia.spec.js
+++ b/tests/unit/components/gallery/HDGalleryMedia.spec.js
@@ -2,13 +2,15 @@ import { wrapperFactoryBuilder } from 'tests/unit/helpers';
 import HdGalleryMedia from '@/components/gallery/HdGalleryMedia.vue';
 import ITEMS from '@/stories/mocks/GALLERY_ITEMS';
 
+const wrapperFactory = wrapperFactoryBuilder(HdGalleryMedia, {
+  props: {
+    item: ITEMS[0],
+  },
+});
+
 describe('HdGalleryMedia', () => {
   const build = (props) => {
-    const wrapper = wrapperFactoryBuilder(HdGalleryMedia, {
-      props: {
-        item: ITEMS[0],
-      },
-    })({ props });
+    const wrapper = wrapperFactory({ props });
 
     return {
       wrapper,
@@ -22,21 +24,45 @@ describe('HdGalleryMedia', () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it('hides the thumbnail when the image is loaded', async () => {
-    const { wrapper, img, thumbnail } = build();
+  it('hides the thumbnail when is not provided', async () => {
+    const itemWithoutThumb = { ...ITEMS[0], thumbnail: null };
+    const { thumbnail } = build({ item: itemWithoutThumb });
 
+    expect(thumbnail().exists()).toBe(false);
+  });
+
+  it('checks the thumbnail when an item change', async () => {
+    const expectedItem = ITEMS[0];
+    const newPictureWithSameImage = {
+      ...ITEMS[0],
+      caption: 'Same Image',
+    };
+    const newPictureWithDifferentImage = ITEMS[1];
+
+    const { wrapper, thumbnail, img } = build({ item: expectedItem });
+
+    // load component
     expect(thumbnail().classes()).toContain('isVisible');
 
     img().trigger('load');
     await wrapper.vm.$nextTick();
 
     expect(thumbnail().classes()).not.toContain('isVisible');
-  });
 
-  it('hides the thumbnail when is not provided', async () => {
-    const itemWithoutThumb = { ...ITEMS[0], thumbnail: null };
-    const { thumbnail } = build({ item: itemWithoutThumb });
+    // change item with the same image
+    wrapper.setProps({
+      item: newPictureWithSameImage,
+    });
+    await wrapper.vm.$nextTick();
 
-    expect(thumbnail().exists()).toBe(false);
+    expect(thumbnail().classes()).not.toContain('isVisible');
+
+    // change item with a different image
+    wrapper.setProps({
+      item: newPictureWithDifferentImage,
+    });
+    await wrapper.vm.$nextTick();
+
+    expect(thumbnail().classes()).toContain('isVisible');
   });
 });

--- a/tests/unit/components/gallery/HDGalleryMedia.spec.js
+++ b/tests/unit/components/gallery/HDGalleryMedia.spec.js
@@ -1,15 +1,14 @@
-import _ from 'lodash';
 import { wrapperFactoryBuilder } from 'tests/unit/helpers';
 import HdGalleryMedia from '@/components/gallery/HdGalleryMedia.vue';
 import ITEMS from '@/stories/mocks/GALLERY_ITEMS';
 
 describe('HdGalleryMedia', () => {
-  const build = (props = {}) => {
+  const build = (props) => {
     const wrapper = wrapperFactoryBuilder(HdGalleryMedia, {
-      props: _.assign({
+      props: {
         item: ITEMS[0],
-      }, props),
-    })();
+      },
+    })({ props });
 
     return {
       wrapper,

--- a/tests/unit/components/gallery/HDGalleryMedia.spec.js
+++ b/tests/unit/components/gallery/HDGalleryMedia.spec.js
@@ -24,14 +24,14 @@ describe('HdGalleryMedia', () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it('hides the thumbnail when is not provided', async () => {
+  it('hides the thumbnail when it is not provided', async () => {
     const itemWithoutThumb = { ...ITEMS[0], thumbnail: null };
     const { thumbnail } = build({ item: itemWithoutThumb });
 
     expect(thumbnail().exists()).toBe(false);
   });
 
-  it('checks the thumbnail when an item change', async () => {
+  it('shows thumbnail when item changes', async () => {
     const expectedItem = ITEMS[0];
     const newPictureWithSameImage = {
       ...ITEMS[0],

--- a/tests/unit/components/gallery/HDGalleryMedia.spec.js
+++ b/tests/unit/components/gallery/HDGalleryMedia.spec.js
@@ -6,7 +6,7 @@ import ITEMS from '@/stories/mocks/GALLERY_ITEMS';
 describe('HdGalleryMedia', () => {
   const build = (props = {}) => {
     const wrapper = wrapperFactoryBuilder(HdGalleryMedia, {
-      props: _.merge({
+      props: _.assign({
         item: ITEMS[0],
       }, props),
     })();

--- a/tests/unit/components/gallery/HdGalleryCarousel.spec.js
+++ b/tests/unit/components/gallery/HdGalleryCarousel.spec.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { wrapperFactoryBuilder } from 'tests/unit/helpers';
 import onResize from 'homeday-blocks/src/services/on-resize';
 import HdGalleryCarousel from '@/components/gallery/HdGalleryCarousel.vue';
@@ -7,12 +6,12 @@ import ITEMS from '@/stories/mocks/GALLERY_ITEMS';
 jest.mock('homeday-blocks/src/services/on-resize');
 
 describe('HdGalleryCarousel', () => {
-  const build = (props = {}) => {
+  const build = (props) => {
     const wrapper = wrapperFactoryBuilder(HdGalleryCarousel, {
-      props: _.assign({
+      props: {
         items: ITEMS,
-      }, props),
-    })();
+      },
+    })({ props });
 
     return {
       wrapper,

--- a/tests/unit/components/gallery/HdGalleryCarousel.spec.js
+++ b/tests/unit/components/gallery/HdGalleryCarousel.spec.js
@@ -5,13 +5,15 @@ import ITEMS from '@/stories/mocks/GALLERY_ITEMS';
 
 jest.mock('homeday-blocks/src/services/on-resize');
 
+const wrapperFactory = wrapperFactoryBuilder(HdGalleryCarousel, {
+  props: {
+    items: ITEMS,
+  },
+});
+
 describe('HdGalleryCarousel', () => {
   const build = (props) => {
-    const wrapper = wrapperFactoryBuilder(HdGalleryCarousel, {
-      props: {
-        items: ITEMS,
-      },
-    })({ props });
+    const wrapper = wrapperFactory({ props });
 
     return {
       wrapper,

--- a/tests/unit/components/gallery/HdGalleryCarousel.spec.js
+++ b/tests/unit/components/gallery/HdGalleryCarousel.spec.js
@@ -1,25 +1,92 @@
+import _ from 'lodash';
 import { wrapperFactoryBuilder } from 'tests/unit/helpers';
+import onResize from 'homeday-blocks/src/services/on-resize';
 import HdGalleryCarousel from '@/components/gallery/HdGalleryCarousel.vue';
 import ITEMS from '@/stories/mocks/GALLERY_ITEMS';
 
-const GALLERY_ITEM_SELECTOR = '.gallery-carousel__item';
-
-const wrapperBuilder = wrapperFactoryBuilder(HdGalleryCarousel, {
-  props: {
-    items: ITEMS,
-  },
-});
+jest.mock('homeday-blocks/src/services/on-resize');
 
 describe('HdGalleryCarousel', () => {
-  it('should render as expected', () => {
-    const wrapper = wrapperBuilder();
+  const build = (props = {}) => {
+    const wrapper = wrapperFactoryBuilder(HdGalleryCarousel, {
+      props: _.assign({
+        items: ITEMS,
+      }, props),
+    })();
 
+    return {
+      wrapper,
+      galleryItems: () => wrapper.findAll('.gallery-carousel__item'),
+      pager: () => wrapper.find('.gallery-carousel__pager'),
+      flickity: () => wrapper.find({ ref: 'flickity' }),
+      wrap: () => wrapper.find('.gallery-carousel__wrap'),
+      activeThumbnailImg: () => wrapper.find('.is-active img'),
+    };
+  };
+
+  it('should render as expected', () => {
+    const { wrapper } = build();
     expect(wrapper.html()).toMatchSnapshot();
   });
 
   it('should render items correctly', () => {
-    const wrapper = wrapperBuilder();
+    const { galleryItems } = build();
 
-    expect(wrapper.findAll(GALLERY_ITEM_SELECTOR).length).toEqual(ITEMS.length);
+    expect(galleryItems()).toHaveLength(ITEMS.length);
+    ITEMS.forEach(({ caption, thumbnail }, index) => {
+      const img = galleryItems().at(index).get('img');
+      expect(img.attributes().alt).toBe(caption);
+      expect(img.attributes().src).toBe(thumbnail);
+    });
+  });
+
+  it('should dispose component listeners', async () => {
+    const { wrapper, flickity } = build();
+    const offSpy = jest.spyOn(flickity().vm, 'off');
+
+    await wrapper.vm.$nextTick();
+    wrapper.destroy();
+
+    expect(offSpy).toHaveBeenNthCalledWith(1, 'change', expect.anything());
+    expect(offSpy).toHaveBeenNthCalledWith(2, 'staticClick', expect.anything());
+    expect(onResize.offDebounced).toHaveBeenCalled();
+  });
+
+  it('should change selected gallery item when user types directional keys', async () => {
+    const items = [ITEMS[3], ITEMS[4]];
+    const {
+      wrapper, activeThumbnailImg, wrap,
+    } = build({
+      items,
+    });
+
+    console.log(items);
+
+    await wrapper.vm.$nextTick();
+    await wrap().trigger('keydown', { key: 'ArrowRight' });
+
+    expect(activeThumbnailImg().attributes().alt).toBe(items[0].caption);
+    expect(activeThumbnailImg().attributes().src).toBe(items[0].thumbnail);
+    expect(wrapper.emitted('input')[0][0]).toBe(1);
+
+    await wrapper.setProps({ value: 1 });
+    await wrapper.vm.$nextTick();
+    await wrap().trigger('keydown', { key: 'ArrowRight' });
+    await wrapper.vm.$nextTick();
+
+    // console.log(wrapper.html());
+
+    // expect(activeThumbnailImg().attributes().alt).toBe(items[1].caption);
+    // expect(activeThumbnailImg().attributes().src).toBe(items[1].thumbnail);
+
+    // await wrap().trigger('keydown', { key: 'ArrowLeft' });
+
+    // expect(activeThumbnailImg().attributes().alt).toBe(items[0].caption);
+    // expect(activeThumbnailImg().attributes().src).toBe(items[0].thumbnail);
+
+    // await wrap().trigger('keydown', { key: 'ArrowLeft' });
+
+    // expect(activeThumbnailImg().attributes().alt).toBe(items[1].caption);
+    // expect(activeThumbnailImg().attributes().src).toBe(items[1].thumbnail);
   });
 });

--- a/tests/unit/components/gallery/HdGalleryCarousel.spec.js
+++ b/tests/unit/components/gallery/HdGalleryCarousel.spec.js
@@ -20,7 +20,8 @@ describe('HdGalleryCarousel', () => {
       pager: () => wrapper.find('.gallery-carousel__pager'),
       flickity: () => wrapper.find({ ref: 'flickity' }),
       wrap: () => wrapper.find('.gallery-carousel__wrap'),
-      activeThumbnailImg: () => wrapper.find('.is-active img'),
+      activeThumbnail: () => wrapper.find('.is-active'),
+      activeThumbnailImg: () => wrapper.find('.is-active').find('img'),
     };
   };
 
@@ -55,38 +56,47 @@ describe('HdGalleryCarousel', () => {
   it('should change selected gallery item when user types directional keys', async () => {
     const items = [ITEMS[3], ITEMS[4]];
     const {
-      wrapper, activeThumbnailImg, wrap,
+      wrapper, activeThumbnail, activeThumbnailImg, wrap,
     } = build({
       items,
     });
 
-    console.log(items);
-
     await wrapper.vm.$nextTick();
+
+    // no current thumbnail is "active" until
+    // we trigger any change inside the carousel
+    expect(activeThumbnail().exists()).toBe(false);
+
+    let nextIndex = 1;
     await wrap().trigger('keydown', { key: 'ArrowRight' });
+    await wrapper.setProps({ value: nextIndex });
+
+    expect(activeThumbnailImg().attributes().alt).toBe(items[1].caption);
+    expect(activeThumbnailImg().attributes().src).toBe(items[1].thumbnail);
+    expect(wrapper.emitted('input')[0][0]).toBe(nextIndex);
+
+    nextIndex = 0;
+    await wrap().trigger('keydown', { key: 'ArrowDown' });
+    await wrapper.setProps({ value: nextIndex });
 
     expect(activeThumbnailImg().attributes().alt).toBe(items[0].caption);
     expect(activeThumbnailImg().attributes().src).toBe(items[0].thumbnail);
-    expect(wrapper.emitted('input')[0][0]).toBe(1);
+    expect(wrapper.emitted('input')[1][0]).toBe(nextIndex);
 
-    await wrapper.setProps({ value: 1 });
-    await wrapper.vm.$nextTick();
-    await wrap().trigger('keydown', { key: 'ArrowRight' });
-    await wrapper.vm.$nextTick();
+    nextIndex = 1;
+    await wrap().trigger('keydown', { key: 'ArrowLeft' });
+    await wrapper.setProps({ value: nextIndex });
 
-    // console.log(wrapper.html());
+    expect(activeThumbnailImg().attributes().alt).toBe(items[1].caption);
+    expect(activeThumbnailImg().attributes().src).toBe(items[1].thumbnail);
+    expect(wrapper.emitted('input')[2][0]).toBe(nextIndex);
 
-    // expect(activeThumbnailImg().attributes().alt).toBe(items[1].caption);
-    // expect(activeThumbnailImg().attributes().src).toBe(items[1].thumbnail);
+    nextIndex = 0;
+    await wrap().trigger('keydown', { key: 'ArrowUp' });
+    await wrapper.setProps({ value: nextIndex });
 
-    // await wrap().trigger('keydown', { key: 'ArrowLeft' });
-
-    // expect(activeThumbnailImg().attributes().alt).toBe(items[0].caption);
-    // expect(activeThumbnailImg().attributes().src).toBe(items[0].thumbnail);
-
-    // await wrap().trigger('keydown', { key: 'ArrowLeft' });
-
-    // expect(activeThumbnailImg().attributes().alt).toBe(items[1].caption);
-    // expect(activeThumbnailImg().attributes().src).toBe(items[1].thumbnail);
+    expect(activeThumbnailImg().attributes().alt).toBe(items[0].caption);
+    expect(activeThumbnailImg().attributes().src).toBe(items[0].thumbnail);
+    expect(wrapper.emitted('input')[3][0]).toBe(nextIndex);
   });
 });

--- a/tests/unit/components/gallery/HdGalleryPlaceholder.spec.js
+++ b/tests/unit/components/gallery/HdGalleryPlaceholder.spec.js
@@ -1,14 +1,16 @@
 import { wrapperFactoryBuilder } from 'tests/unit/helpers';
 import HdGalleryPlaceholder from '@/components/gallery/HdGalleryPlaceholder.vue';
 
+const wrapperFactory = wrapperFactoryBuilder(HdGalleryPlaceholder, {
+  props: {
+    icon: '',
+    text: '',
+  },
+});
+
 describe('HdGalleryPlaceholder', () => {
   const build = (props) => {
-    const wrapper = wrapperFactoryBuilder(HdGalleryPlaceholder, {
-      props: {
-        icon: '',
-        text: '',
-      },
-    })({ props });
+    const wrapper = wrapperFactory({ props });
 
     return {
       wrapper,

--- a/tests/unit/components/gallery/HdGalleryPlaceholder.spec.js
+++ b/tests/unit/components/gallery/HdGalleryPlaceholder.spec.js
@@ -5,7 +5,7 @@ import HdGalleryPlaceholder from '@/components/gallery/HdGalleryPlaceholder.vue'
 describe('HdGalleryPlaceholder', () => {
   const build = (props = {}) => {
     const wrapper = wrapperFactoryBuilder(HdGalleryPlaceholder, {
-      props: _.merge({
+      props: _.assign({
         icon: '',
         text: '',
       }, props),

--- a/tests/unit/components/gallery/HdGalleryPlaceholder.spec.js
+++ b/tests/unit/components/gallery/HdGalleryPlaceholder.spec.js
@@ -1,15 +1,14 @@
-import _ from 'lodash';
 import { wrapperFactoryBuilder } from 'tests/unit/helpers';
 import HdGalleryPlaceholder from '@/components/gallery/HdGalleryPlaceholder.vue';
 
 describe('HdGalleryPlaceholder', () => {
-  const build = (props = {}) => {
+  const build = (props) => {
     const wrapper = wrapperFactoryBuilder(HdGalleryPlaceholder, {
-      props: _.assign({
+      props: {
         icon: '',
         text: '',
-      }, props),
-    })();
+      },
+    })({ props });
 
     return {
       wrapper,

--- a/tests/unit/components/gallery/HdGalleryPlaceholder.spec.js
+++ b/tests/unit/components/gallery/HdGalleryPlaceholder.spec.js
@@ -1,0 +1,31 @@
+import _ from 'lodash';
+import { wrapperFactoryBuilder } from 'tests/unit/helpers';
+import HdGalleryPlaceholder from '@/components/gallery/HdGalleryPlaceholder.vue';
+
+describe('HdGalleryPlaceholder', () => {
+  const build = (props = {}) => {
+    const wrapper = wrapperFactoryBuilder(HdGalleryPlaceholder, {
+      props: _.merge({
+        icon: '',
+        text: '',
+      }, props),
+    })();
+
+    return {
+      wrapper,
+      img: () => wrapper.find('img'),
+    };
+  };
+
+  it('renders placeholder content', () => {
+    const expectedIcon = 'src/assets/icons/ic-error.svg';
+    const expectedText = 'Foo Fighters is an American rock band, formed in Seattle';
+    const { wrapper, img } = build({
+      icon: expectedIcon,
+      text: expectedText,
+    });
+
+    expect(wrapper.text()).toContain(expectedText);
+    expect(img().attributes().src).toBe(expectedIcon);
+  });
+});

--- a/tests/unit/components/gallery/__snapshots__/HDGallery.spec.js.snap
+++ b/tests/unit/components/gallery/__snapshots__/HDGallery.spec.js.snap
@@ -30,44 +30,44 @@ exports[`HdGalleryCarousel renders the component 1`] = `
           <div class="flickity-slider" style="left: 0px; transform: translateX(NaN%);">
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
               <div style="padding-top: 56.25%;"></div>
-              <picture class="gallery-carousel__item-picture">
+              <picture class="gallery-carousel__picture">
                 <source media="(max-width: 900px)" srcset="https://dummyimage.com/768x432?text=1+thumb+mw+900px"> <img src="https://dummyimage.com/154x86?text=1+thumb" alt="Image 1"></picture>
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
               <div style="padding-top: 56.25%;"></div>
-              <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=2+thumb" alt="Image 2" srcset="https://dummyimage.com/308x172?text=2+thumb+DPR2x 2x, https://dummyimage.com/462x258?text=2+thumb+DPR3x 3x"></picture>
+              <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=2+thumb" alt="Image 2" srcset="https://dummyimage.com/308x172?text=2+thumb+DPR2x 2x, https://dummyimage.com/462x258?text=2+thumb+DPR3x 3x"></picture>
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
               <div style="padding-top: 56.25%;"></div>
-              <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=3+thumb" alt="Image 3"></picture>
+              <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=3+thumb" alt="Image 3"></picture>
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
               <div style="padding-top: 56.25%;"></div>
-              <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=4+thumb" alt="Image 4"></picture>
+              <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=4+thumb" alt="Image 4"></picture>
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
               <div style="padding-top: 56.25%;"></div>
-              <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=5+thumb" alt="Image 5"></picture>
+              <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=5+thumb" alt="Image 5"></picture>
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
               <div style="padding-top: 56.25%;"></div>
-              <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=6+thumb" alt="Image 6"></picture>
+              <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=6+thumb" alt="Image 6"></picture>
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
               <div style="padding-top: 56.25%;"></div>
-              <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=7+thumb" alt="Image 7"></picture>
+              <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=7+thumb" alt="Image 7"></picture>
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
               <div style="padding-top: 56.25%;"></div>
-              <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=8+thumb" alt="Image 8"></picture>
+              <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=8+thumb" alt="Image 8"></picture>
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
               <div style="padding-top: 56.25%;"></div>
-              <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=9+thumb" alt="Image 9"></picture>
+              <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=9+thumb" alt="Image 9"></picture>
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
               <div style="padding-top: 56.25%;"></div>
-              <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=10+thumb" alt="Image 10"></picture>
+              <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=10+thumb" alt="Image 10"></picture>
             </div>
           </div>
         </div>

--- a/tests/unit/components/gallery/__snapshots__/HDGallery.spec.js.snap
+++ b/tests/unit/components/gallery/__snapshots__/HDGallery.spec.js.snap
@@ -8,12 +8,12 @@ exports[`HdGallery renders component 1`] = `
       <div class="gallery__image">
         <div class="gallery-media">
           <div class="gallery-media__object">
-            <div class="gallery-media__object__sizer" style="padding-top: 56.25%;"></div>
-            <picture class="gallery-media__object__picture">
+            <div style="padding-top: 56.25%;"></div>
+            <picture class="gallery-media__object-picture">
               <source media="(max-width: 600px)" srcset="https://dummyimage.com/306x172?text=1+mw+600px">
               <source media="(max-width: 900px)" srcset="https://dummyimage.com/768x432?text=1+mw+900px">
               <source media="(max-width: 1200px)" srcset="https://dummyimage.com/768x432?text=1+mw+1200px"> <img src="https://dummyimage.com/1536x364?text=1" alt="Image 1"></picture>
-            <div class="gallery-media__object__thumbnail isVisible" style="background-image: url(https://dummyimage.com/154x86?text=1+thumb);"></div>
+            <div class="gallery-media__object-thumbnail isVisible" style="background-image: url(https://dummyimage.com/154x86?text=1+thumb);"></div>
           </div>
         </div>
       </div>

--- a/tests/unit/components/gallery/__snapshots__/HDGallery.spec.js.snap
+++ b/tests/unit/components/gallery/__snapshots__/HDGallery.spec.js.snap
@@ -23,51 +23,51 @@ exports[`HdGallery renders component 1`] = `
       <p class="gallery__info">1/10</p>
     </div>
   </figure>
-  <div class="gallery__carousel gallery-carousel">
+  <div class="gallery-carousel gallery__carousel">
     <div tabindex="0" class="gallery-carousel__wrap">
       <div class="flickity-enabled">
         <div class="flickity-viewport" style="height: 0px;">
           <div class="flickity-slider" style="left: 0px; transform: translateX(NaN%);">
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
-              <div class="gallery-carousel__item__sizer" style="padding-top: 56.25%;"></div>
-              <picture class="gallery-carousel__item__picture">
+              <div style="padding-top: 56.25%;"></div>
+              <picture class="gallery-carousel__item-picture">
                 <source media="(max-width: 900px)" srcset="https://dummyimage.com/768x432?text=1+thumb+mw+900px"> <img src="https://dummyimage.com/154x86?text=1+thumb" alt="Image 1"></picture>
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
-              <div class="gallery-carousel__item__sizer" style="padding-top: 56.25%;"></div>
-              <picture class="gallery-carousel__item__picture"> <img src="https://dummyimage.com/154x86?text=2+thumb" alt="Image 2" srcset="https://dummyimage.com/308x172?text=2+thumb+DPR2x 2x, https://dummyimage.com/462x258?text=2+thumb+DPR3x 3x"></picture>
+              <div style="padding-top: 56.25%;"></div>
+              <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=2+thumb" alt="Image 2" srcset="https://dummyimage.com/308x172?text=2+thumb+DPR2x 2x, https://dummyimage.com/462x258?text=2+thumb+DPR3x 3x"></picture>
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
-              <div class="gallery-carousel__item__sizer" style="padding-top: 56.25%;"></div>
-              <picture class="gallery-carousel__item__picture"> <img src="https://dummyimage.com/154x86?text=3+thumb" alt="Image 3"></picture>
+              <div style="padding-top: 56.25%;"></div>
+              <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=3+thumb" alt="Image 3"></picture>
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
-              <div class="gallery-carousel__item__sizer" style="padding-top: 56.25%;"></div>
-              <picture class="gallery-carousel__item__picture"> <img src="https://dummyimage.com/154x86?text=4+thumb" alt="Image 4"></picture>
+              <div style="padding-top: 56.25%;"></div>
+              <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=4+thumb" alt="Image 4"></picture>
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
-              <div class="gallery-carousel__item__sizer" style="padding-top: 56.25%;"></div>
-              <picture class="gallery-carousel__item__picture"> <img src="https://dummyimage.com/154x86?text=5+thumb" alt="Image 5"></picture>
+              <div style="padding-top: 56.25%;"></div>
+              <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=5+thumb" alt="Image 5"></picture>
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
-              <div class="gallery-carousel__item__sizer" style="padding-top: 56.25%;"></div>
-              <picture class="gallery-carousel__item__picture"> <img src="https://dummyimage.com/154x86?text=6+thumb" alt="Image 6"></picture>
+              <div style="padding-top: 56.25%;"></div>
+              <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=6+thumb" alt="Image 6"></picture>
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
-              <div class="gallery-carousel__item__sizer" style="padding-top: 56.25%;"></div>
-              <picture class="gallery-carousel__item__picture"> <img src="https://dummyimage.com/154x86?text=7+thumb" alt="Image 7"></picture>
+              <div style="padding-top: 56.25%;"></div>
+              <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=7+thumb" alt="Image 7"></picture>
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
-              <div class="gallery-carousel__item__sizer" style="padding-top: 56.25%;"></div>
-              <picture class="gallery-carousel__item__picture"> <img src="https://dummyimage.com/154x86?text=8+thumb" alt="Image 8"></picture>
+              <div style="padding-top: 56.25%;"></div>
+              <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=8+thumb" alt="Image 8"></picture>
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
-              <div class="gallery-carousel__item__sizer" style="padding-top: 56.25%;"></div>
-              <picture class="gallery-carousel__item__picture"> <img src="https://dummyimage.com/154x86?text=9+thumb" alt="Image 9"></picture>
+              <div style="padding-top: 56.25%;"></div>
+              <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=9+thumb" alt="Image 9"></picture>
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
-              <div class="gallery-carousel__item__sizer" style="padding-top: 56.25%;"></div>
-              <picture class="gallery-carousel__item__picture"> <img src="https://dummyimage.com/154x86?text=10+thumb" alt="Image 10"></picture>
+              <div style="padding-top: 56.25%;"></div>
+              <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=10+thumb" alt="Image 10"></picture>
             </div>
           </div>
         </div>

--- a/tests/unit/components/gallery/__snapshots__/HDGallery.spec.js.snap
+++ b/tests/unit/components/gallery/__snapshots__/HDGallery.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HdGalleryCarousel renders the component 1`] = `
+exports[`HdGallery renders the component 1`] = `
 <div class="gallery">
   <figure class="gallery__figure">
     <figcaption class="gallery__caption">Image 1</figcaption>

--- a/tests/unit/components/gallery/__snapshots__/HDGallery.spec.js.snap
+++ b/tests/unit/components/gallery/__snapshots__/HDGallery.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HdGallery renders component 1`] = `
+exports[`HdGalleryCarousel renders the component 1`] = `
 <div class="gallery">
   <figure class="gallery__figure">
     <figcaption class="gallery__caption">Image 1</figcaption>
@@ -17,8 +17,8 @@ exports[`HdGallery renders component 1`] = `
           </div>
         </div>
       </div>
-      <div class="gallery__controls"><button type="button" class="gallery__controls__prev isDisabled">
-          <!----></button> <button type="button" class="gallery__controls__next">
+      <div class="gallery__controls"><button type="button" class="gallery__controls-prev isDisabled">
+          <!----></button> <button type="button" class="gallery__controls-next">
           <!----></button></div>
       <p class="gallery__info">1/10</p>
     </div>

--- a/tests/unit/components/gallery/__snapshots__/HDGalleryMedia.spec.js.snap
+++ b/tests/unit/components/gallery/__snapshots__/HDGalleryMedia.spec.js.snap
@@ -3,12 +3,12 @@
 exports[`HdGalleryMedia renders component 1`] = `
 <div class="gallery-media">
   <div class="gallery-media__object">
-    <div class="gallery-media__object__sizer" style="padding-top: 56.25%;"></div>
-    <picture class="gallery-media__object__picture">
+    <div style="padding-top: 56.25%;"></div>
+    <picture class="gallery-media__object-picture">
       <source media="(max-width: 600px)" srcset="https://dummyimage.com/306x172?text=1+mw+600px">
       <source media="(max-width: 900px)" srcset="https://dummyimage.com/768x432?text=1+mw+900px">
       <source media="(max-width: 1200px)" srcset="https://dummyimage.com/768x432?text=1+mw+1200px"> <img src="https://dummyimage.com/1536x364?text=1" alt="Image 1"></picture>
-    <div class="gallery-media__object__thumbnail isVisible" style="background-image: url(https://dummyimage.com/154x86?text=1+thumb);"></div>
+    <div class="gallery-media__object-thumbnail isVisible" style="background-image: url(https://dummyimage.com/154x86?text=1+thumb);"></div>
   </div>
 </div>
 `;

--- a/tests/unit/components/gallery/__snapshots__/HdGalleryCarousel.spec.js.snap
+++ b/tests/unit/components/gallery/__snapshots__/HdGalleryCarousel.spec.js.snap
@@ -8,44 +8,44 @@ exports[`HdGalleryCarousel should render as expected 1`] = `
         <div class="flickity-slider" style="left: 0px; transform: translateX(NaN%);">
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
             <div style="padding-top: 56.25%;"></div>
-            <picture class="gallery-carousel__item-picture">
+            <picture class="gallery-carousel__picture">
               <source media="(max-width: 900px)" srcset="https://dummyimage.com/768x432?text=1+thumb+mw+900px"> <img src="https://dummyimage.com/154x86?text=1+thumb" alt="Image 1"></picture>
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
             <div style="padding-top: 56.25%;"></div>
-            <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=2+thumb" alt="Image 2" srcset="https://dummyimage.com/308x172?text=2+thumb+DPR2x 2x, https://dummyimage.com/462x258?text=2+thumb+DPR3x 3x"></picture>
+            <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=2+thumb" alt="Image 2" srcset="https://dummyimage.com/308x172?text=2+thumb+DPR2x 2x, https://dummyimage.com/462x258?text=2+thumb+DPR3x 3x"></picture>
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
             <div style="padding-top: 56.25%;"></div>
-            <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=3+thumb" alt="Image 3"></picture>
+            <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=3+thumb" alt="Image 3"></picture>
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
             <div style="padding-top: 56.25%;"></div>
-            <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=4+thumb" alt="Image 4"></picture>
+            <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=4+thumb" alt="Image 4"></picture>
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
             <div style="padding-top: 56.25%;"></div>
-            <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=5+thumb" alt="Image 5"></picture>
+            <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=5+thumb" alt="Image 5"></picture>
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
             <div style="padding-top: 56.25%;"></div>
-            <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=6+thumb" alt="Image 6"></picture>
+            <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=6+thumb" alt="Image 6"></picture>
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
             <div style="padding-top: 56.25%;"></div>
-            <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=7+thumb" alt="Image 7"></picture>
+            <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=7+thumb" alt="Image 7"></picture>
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
             <div style="padding-top: 56.25%;"></div>
-            <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=8+thumb" alt="Image 8"></picture>
+            <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=8+thumb" alt="Image 8"></picture>
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
             <div style="padding-top: 56.25%;"></div>
-            <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=9+thumb" alt="Image 9"></picture>
+            <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=9+thumb" alt="Image 9"></picture>
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
             <div style="padding-top: 56.25%;"></div>
-            <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=10+thumb" alt="Image 10"></picture>
+            <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=10+thumb" alt="Image 10"></picture>
           </div>
         </div>
       </div>

--- a/tests/unit/components/gallery/__snapshots__/HdGalleryCarousel.spec.js.snap
+++ b/tests/unit/components/gallery/__snapshots__/HdGalleryCarousel.spec.js.snap
@@ -7,45 +7,45 @@ exports[`HdGalleryCarousel should render as expected 1`] = `
       <div class="flickity-viewport" style="height: 0px;">
         <div class="flickity-slider" style="left: 0px; transform: translateX(NaN%);">
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
-            <div class="gallery-carousel__item__sizer" style="padding-top: 56.25%;"></div>
-            <picture class="gallery-carousel__item__picture">
+            <div style="padding-top: 56.25%;"></div>
+            <picture class="gallery-carousel__item-picture">
               <source media="(max-width: 900px)" srcset="https://dummyimage.com/768x432?text=1+thumb+mw+900px"> <img src="https://dummyimage.com/154x86?text=1+thumb" alt="Image 1"></picture>
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
-            <div class="gallery-carousel__item__sizer" style="padding-top: 56.25%;"></div>
-            <picture class="gallery-carousel__item__picture"> <img src="https://dummyimage.com/154x86?text=2+thumb" alt="Image 2" srcset="https://dummyimage.com/308x172?text=2+thumb+DPR2x 2x, https://dummyimage.com/462x258?text=2+thumb+DPR3x 3x"></picture>
+            <div style="padding-top: 56.25%;"></div>
+            <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=2+thumb" alt="Image 2" srcset="https://dummyimage.com/308x172?text=2+thumb+DPR2x 2x, https://dummyimage.com/462x258?text=2+thumb+DPR3x 3x"></picture>
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
-            <div class="gallery-carousel__item__sizer" style="padding-top: 56.25%;"></div>
-            <picture class="gallery-carousel__item__picture"> <img src="https://dummyimage.com/154x86?text=3+thumb" alt="Image 3"></picture>
+            <div style="padding-top: 56.25%;"></div>
+            <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=3+thumb" alt="Image 3"></picture>
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
-            <div class="gallery-carousel__item__sizer" style="padding-top: 56.25%;"></div>
-            <picture class="gallery-carousel__item__picture"> <img src="https://dummyimage.com/154x86?text=4+thumb" alt="Image 4"></picture>
+            <div style="padding-top: 56.25%;"></div>
+            <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=4+thumb" alt="Image 4"></picture>
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
-            <div class="gallery-carousel__item__sizer" style="padding-top: 56.25%;"></div>
-            <picture class="gallery-carousel__item__picture"> <img src="https://dummyimage.com/154x86?text=5+thumb" alt="Image 5"></picture>
+            <div style="padding-top: 56.25%;"></div>
+            <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=5+thumb" alt="Image 5"></picture>
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
-            <div class="gallery-carousel__item__sizer" style="padding-top: 56.25%;"></div>
-            <picture class="gallery-carousel__item__picture"> <img src="https://dummyimage.com/154x86?text=6+thumb" alt="Image 6"></picture>
+            <div style="padding-top: 56.25%;"></div>
+            <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=6+thumb" alt="Image 6"></picture>
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
-            <div class="gallery-carousel__item__sizer" style="padding-top: 56.25%;"></div>
-            <picture class="gallery-carousel__item__picture"> <img src="https://dummyimage.com/154x86?text=7+thumb" alt="Image 7"></picture>
+            <div style="padding-top: 56.25%;"></div>
+            <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=7+thumb" alt="Image 7"></picture>
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
-            <div class="gallery-carousel__item__sizer" style="padding-top: 56.25%;"></div>
-            <picture class="gallery-carousel__item__picture"> <img src="https://dummyimage.com/154x86?text=8+thumb" alt="Image 8"></picture>
+            <div style="padding-top: 56.25%;"></div>
+            <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=8+thumb" alt="Image 8"></picture>
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
-            <div class="gallery-carousel__item__sizer" style="padding-top: 56.25%;"></div>
-            <picture class="gallery-carousel__item__picture"> <img src="https://dummyimage.com/154x86?text=9+thumb" alt="Image 9"></picture>
+            <div style="padding-top: 56.25%;"></div>
+            <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=9+thumb" alt="Image 9"></picture>
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
-            <div class="gallery-carousel__item__sizer" style="padding-top: 56.25%;"></div>
-            <picture class="gallery-carousel__item__picture"> <img src="https://dummyimage.com/154x86?text=10+thumb" alt="Image 10"></picture>
+            <div style="padding-top: 56.25%;"></div>
+            <picture class="gallery-carousel__item-picture"> <img src="https://dummyimage.com/154x86?text=10+thumb" alt="Image 10"></picture>
           </div>
         </div>
       </div>

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -1,4 +1,5 @@
 import { mount, shallowMount } from '@vue/test-utils';
+import deepmerge from 'deepmerge';
 
 export function wrapperFactoryBuilder(
   component,
@@ -8,7 +9,7 @@ export function wrapperFactoryBuilder(
     scopedSlots: defaultScopedSlots,
     stubs: defaultStubs,
     attachToDocument: defaultAttachToDocument,
-    props: defaultProps,
+    props: defaultProps = {},
     listeners: defaultListeners,
     provide: defaultProvide,
     methods: defaultMethods,
@@ -21,7 +22,7 @@ export function wrapperFactoryBuilder(
     scopedSlots,
     stubs,
     attachToDocument = defaultAttachToDocument,
-    props,
+    props = {},
     listeners,
     provide,
     methods,
@@ -47,10 +48,7 @@ export function wrapperFactoryBuilder(
         ...stubs,
       },
       attachToDocument,
-      propsData: {
-        ...defaultProps,
-        ...props,
-      },
+      propsData: deepmerge(defaultProps, props, { arrayMerge: (_, sourceArray) => sourceArray }),
       listeners: {
         ...defaultListeners,
         ...listeners,


### PR DESCRIPTION
This PR closes ticket [FET-46](https://homeday.atlassian.net/secure/RapidBoard.jspa?rapidView=22&projectKey=FET&modal=detail&selectedIssue=FET-46) and PR #480 

In this PR:

- Create tests for Gallery components
  - [x] HdGallery **(Integration/Unit)**
  - [x] HdGalleryMedia **(Unit)**
  - [x] HdGalleryPlaceholder **(Unit)**
  - [x] HdGalleryCarousel **(Unit)**
- Fix lint error in some of those components
- Change some css selectors names to avoid using more than one element nesting
  - Descending two elements in BEM is not recommended (e.g: `block__element__element2`)
  - If we fall in that situation we can:
    - Rename the selector to something like `block__element-element2`
    - If this doesn't make sense, the component structure need to be re-structured

![image](https://user-images.githubusercontent.com/1855125/91441088-e89f7680-e86f-11ea-824e-9de78936171a.png)
