### PR TITLE
[T] Sort stories alphabetically

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -9,6 +9,7 @@ export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
   options: {
     storySort: {
+      method: 'alphabetical',
       order: [
         'Introduction'
       ]


### PR DESCRIPTION
In this PR:

Originally, storybook sorts its stories by import order.

- Change storybook configuration file to sort stories alphabetically


| Before | After |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/1855125/91441715-fd303e80-e870-11ea-80cf-d4bf16cbd016.png) |  ![image](https://user-images.githubusercontent.com/1855125/91441595-cb1edc80-e870-11ea-9da3-83b49d4681ad.png)  |