### PR TITLE
[T] update Google Maps API to version 3.42

### DIFF
--- a/src/services/googleAPI.js
+++ b/src/services/googleAPI.js
@@ -8,8 +8,10 @@ export function getGoogleAPI(key) {
   }
 
   mapsApiPromise = new Promise((resolve) => {
+    // Check Google Maps version documentation: https://developers.google.com/maps/documentation/javascript/versions
+    const version = '3.42';
     loadScript({
-      url: `https://maps.googleapis.com/maps/api/js?v=3.37&key=${key}&libraries=places&region=DE`,
+      url: `https://maps.googleapis.com/maps/api/js?v=${version}&key=${key}&libraries=places&region=DE`,
     }).then(() => {
       resolve(window.google);
     }).catch(() => {


### PR DESCRIPTION
- 📌 (GoogleMaps): update to version 3.42

---

I noticed that on MyHomeday a warning was prompting on the console:

<img width="462" alt="Screen Shot 2020-08-31 at 11 53 21" src="https://user-images.githubusercontent.com/7268262/91747928-b4d09380-eb84-11ea-9064-51f5ac0fa3e2.png">

After taking a look at the [version documentation](https://developers.google.com/maps/documentation/javascript/versions) of Google Maps, it seems that the only versions considered to be currently supported are: `3.40`, `3.41`, and `3.42`.

So I bumped it to `3.42`.
