### PR TITLE
[F] Add indeterminate state to HdCheckbox

### DIFF
--- a/src/components/form/HdCheckbox.vue
+++ b/src/components/form/HdCheckbox.vue
@@ -7,6 +7,7 @@
       'isChecked': isChecked,
       'hasError': !!error,
       'isUsingMouse': isUsingMouse,
+      'checkbox--indeterminate': indeterminate,
     }"
     :key="error+isChecked"
     @keydown="setUsingMouse(false)"
@@ -104,6 +105,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    indeterminate: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     return {
@@ -173,6 +178,20 @@ export default {
 
   &--disabled {
     pointer-events: none;
+  }
+
+  &--indeterminate {
+    ::v-deep .checkbox__inner__box::before {
+      content: '';
+      display: block;
+      background: getShade($quaternary-color, 80);
+      width: 50%;
+      height: 2px;
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      transform: translate(-50%, -50%);
+    }
   }
 
   &__input {


### PR DESCRIPTION
This PR closes the ticket: https://homeday.atlassian.net/browse/FET-201

I moved the handling of indeterminate state from [customer-app](https://github.com/homeday-de/customer-app/blob/0517ad46b17d4f81a73e651f4323f8ac71ea9347/src/views/panelViews/DocumentsDataRoom.vue#L30) to homeday-blocks.

I didn't add property updates on the checkbox field (as described [here](https://css-tricks.com/indeterminate-checkboxes/)), since it's useful only for default styling purposes, which we don't need.