### PR TITLE
[T] Consistency in underlining in the shared valuation results

### DIFF
--- a/src/assets/patterns/dash-pattern-horizontal.svg
+++ b/src/assets/patterns/dash-pattern-horizontal.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100" height="20"><rect x="20" y="5" width="60" height="10" rx="5" fill="#C6CCD4"/></svg>

--- a/src/components/HdDashedList.vue
+++ b/src/components/HdDashedList.vue
@@ -68,7 +68,7 @@ export default {
 
 .dashed-list {
   $root: &;
-  $leaders-border: 2px dashed getShade($neutral-gray, 50);;
+  $leaders-border: 2px dashed getShade($neutral-gray, 50);
   background-color: inherit;
 
   &__item {

--- a/src/components/HdDashedList.vue
+++ b/src/components/HdDashedList.vue
@@ -68,7 +68,7 @@ export default {
 
 .dashed-list {
   $root: &;
-  $leaders-border: 2px dashed #D6DDE6;
+  $leaders-border: 2px dashed getShade($neutral-gray, 50);;
   background-color: inherit;
 
   &__item {

--- a/src/components/HdDashedList.vue
+++ b/src/components/HdDashedList.vue
@@ -25,7 +25,6 @@
             class="dashed-list__text"
             v-html="label"
           />
-          <div class="dashed-list__dashes" />
         </dt>
         <dd class="dashed-list__section">
           <span
@@ -69,6 +68,7 @@ export default {
 
 .dashed-list {
   $root: &;
+  $leaders-border: 2px dashed #D6DDE6;
   background-color: inherit;
 
   &__item {
@@ -85,6 +85,8 @@ export default {
   &__section {
     display: flex;
     align-items: flex-end;
+    position: relative;
+    overflow: hidden;
 
     &--label {
       width: 100%;
@@ -97,6 +99,15 @@ export default {
       #{$root}__text {
         @media (min-width: $break-tablet) {
           max-width: 60%;
+
+          &:after {
+            content: "";
+            position: absolute;
+            border-bottom: $leaders-border;
+            margin-left: 2px;
+            margin-top: 1.03em;
+            width: 100%;
+          }
         }
       }
 
@@ -129,11 +140,9 @@ export default {
   }
 
   &__dashes {
-    height: 2px;
     flex: 1;
-    background-image: url('~homeday-blocks/src/assets/patterns/dash-pattern-horizontal.svg');
-    background-size: contain;
     margin-bottom: .4em;
+    border-bottom: $leaders-border;
   }
 }
 </style>

--- a/tests/unit/components/__snapshots__/HdDashedList.spec.js.snap
+++ b/tests/unit/components/__snapshots__/HdDashedList.spec.js.snap
@@ -4,17 +4,13 @@ exports[`HdDashedList renders component 1`] = `
 <dl class="dashed-list">
   <!---->
   <div class="dashed-list__item">
-    <dt class="dashed-list__section dashed-list__section--label"><span class="dashed-list__text">item 1</span>
-      <div class="dashed-list__dashes"></div>
-    </dt>
+    <dt class="dashed-list__section dashed-list__section--label"><span class="dashed-list__text">item 1</span></dt>
     <dd class="dashed-list__section"><span class="dashed-list__text">1 (value)</span></dd>
     <!---->
   </div>
   <!---->
   <div class="dashed-list__item">
-    <dt class="dashed-list__section dashed-list__section--label"><span class="dashed-list__text">Item 2</span>
-      <div class="dashed-list__dashes"></div>
-    </dt>
+    <dt class="dashed-list__section dashed-list__section--label"><span class="dashed-list__text">Item 2</span></dt>
     <dd class="dashed-list__section"><span class="dashed-list__text">2 (value)</span></dd>
     <dd class="dashed-list__section dashed-list__section--secondary">
       <div class="dashed-list__dashes"></div> <span class="dashed-list__text">2 (secondaryValue)</span>
@@ -24,18 +20,14 @@ exports[`HdDashedList renders component 1`] = `
     Title
   </h4>
   <div class="dashed-list__item">
-    <dt class="dashed-list__section dashed-list__section--label"><span class="dashed-list__text">Item 3</span>
-      <div class="dashed-list__dashes"></div>
-    </dt>
+    <dt class="dashed-list__section dashed-list__section--label"><span class="dashed-list__text">Item 3</span></dt>
     <dd class="dashed-list__section"><span class="dashed-list__text">3</span></dd>
     <dd class="dashed-list__section dashed-list__section--secondary">
       <div class="dashed-list__dashes"></div> <span class="dashed-list__text">3 (secondaryValue)</span>
     </dd>
   </div>
   <div class="dashed-list__item">
-    <dt class="dashed-list__section dashed-list__section--label"><span class="dashed-list__text">Item 4</span>
-      <div class="dashed-list__dashes"></div>
-    </dt>
+    <dt class="dashed-list__section dashed-list__section--label"><span class="dashed-list__text">Item 4</span></dt>
     <dd class="dashed-list__section"><span class="dashed-list__text">4</span></dd>
     <dd class="dashed-list__section dashed-list__section--secondary">
       <div class="dashed-list__dashes"></div> <span class="dashed-list__text">4 (secondaryValue)</span>


### PR DESCRIPTION
[REAL-2751](https://homeday.atlassian.net/browse/REAL-2751)

This PR fixes gaps in dashed leaders that appear with multiline titles: 
<img width="320" alt="Screenshot 2020-08-18 at 14 25 30" src="https://user-images.githubusercontent.com/3431279/93081088-fbe37c00-f68e-11ea-8ceb-475ea3a324ee.png">

