### PR TITLE
[F] Support icon button in HdButton

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@
  */
 module.exports = {
   globalSetup: '<rootDir>/tests/unit/globalSetup.js',
+  setupFiles: ['<rootDir>/tests/unit/setup.js'],
   collectCoverageFrom: [
     'src/components/**/*.vue',
     'src/services/**/*.js',

--- a/src/components/buttons/HdButton.vue
+++ b/src/components/buttons/HdButton.vue
@@ -95,7 +95,7 @@ export default {
   methods: {
     detectIconButton() {
       // It's an icon button if the content element has no text
-      this.isIconButton = !this.$refs.content.innerText;
+      this.isIconButton = !this.$refs.content.textContent.trim();
     },
   },
 };

--- a/src/components/buttons/HdButton.vue
+++ b/src/components/buttons/HdButton.vue
@@ -48,19 +48,19 @@ export default {
     },
   },
   computed: {
+    isIconButton() {
+      return this.$slots.default === undefined;
+    },
     computedClasses() {
       const baseClass = 'btn';
-      const classes = [baseClass];
-
-      if (this.modifier) {
-        classes.push(`${baseClass}--${this.modifier}`);
-      }
-
-      if (this.isInDarkBackground) {
-        classes.push(`${baseClass}--dark-background`);
-      }
-
-      return classes;
+      return [
+        baseClass,
+        {
+          [`${baseClass}--${this.modifier}`]: this.modifier,
+          [`${baseClass}--dark-background`]: this.isInDarkBackground,
+          [`${baseClass}--icon-button`]: this.isIconButton,
+        },
+      ];
     },
   },
 };
@@ -69,11 +69,25 @@ export default {
 <style lang="scss">
 @import 'homeday-blocks/src/styles/_variables.scss';
 
-.btn__icon {
-  margin-right: $inline-xs;
+.btn {
+  $root: &;
 
-  path {
-    fill: currentColor;
+  &--icon-button {
+    padding: $inset-s;
+  }
+
+  &__icon {
+    margin-right: $inline-xs;
+
+    #{$root}--icon-button & {
+      width: 28px;
+      height: 28px;
+      margin-right: 0;
+    }
+
+    path {
+      fill: currentColor;
+    }
   }
 }
 </style>

--- a/src/stories/HdButton.stories.js
+++ b/src/stories/HdButton.stories.js
@@ -96,6 +96,14 @@ Tertiary.args = {
 };
 
 
+export const IconButton = Template.bind({});
+IconButton.args = {
+  modifier: TYPES.PRIMARY,
+  text: '',
+  iconSrc: true,
+};
+
+
 export const Flat = Template.bind({});
 Flat.args = {
   modifier: TYPES.FLAT,

--- a/src/stories/HdButton.stories.js
+++ b/src/stories/HdButton.stories.js
@@ -53,6 +53,13 @@ const Template = (args, { argTypes }) => ({
         :disabled="disabled"
         :iconSrc="icon"
       >{{ text }}</HdButton>
+      <HdButton
+        @click="onClick"
+        :modifier="modifier"
+        :isInDarkBackground="isInDarkBackground"
+        :disabled="disabled"
+        :iconSrc="icon"
+      />
       <div :style="style" />
     </div>
       `,

--- a/src/stories/HdButton.stories.js
+++ b/src/stories/HdButton.stories.js
@@ -53,13 +53,6 @@ const Template = (args, { argTypes }) => ({
         :disabled="disabled"
         :iconSrc="icon"
       >{{ text }}</HdButton>
-      <HdButton
-        @click="onClick"
-        :modifier="modifier"
-        :isInDarkBackground="isInDarkBackground"
-        :disabled="disabled"
-        :iconSrc="icon"
-      />
       <div :style="style" />
     </div>
       `,

--- a/src/styles/buttons.scss
+++ b/src/styles/buttons.scss
@@ -37,6 +37,7 @@ $button-transition: all $time-s ease-in-out;
 }
 
 .btn {
+  position: relative;
   box-sizing: border-box;
   display: inline-flex;
   align-items: center;
@@ -58,6 +59,18 @@ $button-transition: all $time-s ease-in-out;
 
   &:hover {
     cursor: pointer;
+  }
+
+  &::before {
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+    bottom: 0;
+    border: 2px solid transparent;
+    transition: border-color .3s ease-in-out;
   }
 }
 
@@ -107,13 +120,9 @@ $button-transition: all $time-s ease-in-out;
 
 .btn--secondary {
   @include btn-ripple;
-
-  padding: #{$stack-s - 2px} #{$inline-l - 2px}; // adjustment for the border-width of 2px
-  border: 2px solid getShade($secondary-color, 110);
   color: getShade($secondary-color, 110);
   transition: 
     background-color 0.3s ease-in-out,
-    border 0.3s ease-in-out,
     box-shadow 0.3s ease-in-out,
     color 0.3s ease-in-out;
 
@@ -133,24 +142,36 @@ $button-transition: all $time-s ease-in-out;
     background-color: getShade($secondary-color, 110);
   }
 
+  &::before {
+    border-color: getShade($secondary-color, 110);
+  }
+  
   &.btn--dark-background {
-    border: 2px solid $white;
     color: $white;
 
     &:hover,
     &:focus {
-      border: 2px solid getShade($secondary-color, 110);
+      &::before {
+        border-color: getShade($secondary-color, 110);
+      }
+    }
+
+    &::before {
+      border-color: $white;
     }
   }
 
   &[disabled],
   &.btn--disabled {
-    border: 2px solid getShade($neutral-gray, 60);
     color: getShade($neutral-gray, 70);
     box-shadow: none;
 
-    &:after {
+    &::after {
       display: none;
+    }
+    
+    &::before {
+      border-color: getShade($neutral-gray, 60);
     }
 
     &:hover,
@@ -171,28 +192,32 @@ $button-transition: all $time-s ease-in-out;
 .btn--tertiary {
   @include btn-ripple(getShade($secondary-color, 80), multiply, 0.4);
 
-  padding: #{$stack-s - 2px} #{$inline-l - 2px}; // adjustment for the border-width of 2px
-  border: 2px solid transparent;
   background-color: getShade($secondary-color, 70);
   color: getShade($secondary-color, 110);
   transition: 
     background-color 0.3s ease-in-out,
-    border 0.3s ease-in-out,
     padding 0.3s ease-in-out;
 
   &:hover {
     background-color: transparent;
-    border: 2px solid getShade($secondary-color, 110);
+
+    &::before {
+      border-color: getShade($secondary-color, 110);
+    }
   }
 
   &:focus {
     background-color: transparent;
-    border: 2px solid getShade($secondary-color, 110);
+    &::before {
+      border-color: getShade($secondary-color, 110);
+    }
   }
 
   &:active {
     background-color: getShade($secondary-color, 70);
-    border: 2px solid transparent;
+    &::before {
+      border-color: transparent;
+    }
   }
 
   &.btn--dark-background {
@@ -201,29 +226,37 @@ $button-transition: all $time-s ease-in-out;
 
     &:hover,
     &:focus {
-      border: 2px solid white;
+      &::before {
+        border-color: $white;
+      }
     }
   }
 
   &[disabled],
   &.btn--disabled {
     background-color: getShade($neutral-gray, 40);
-    border: 2px solid transparent;
     color: getShade($neutral-gray, 70);
     box-shadow: none;
 
-    &:after {
+    &::after {
       display: none;
+    }
+
+    &::before {
+      border-color: transparent;
     }
 
     &:hover,
     &:active,
     &:focus {
       background-color: getShade($neutral-gray, 40);
-      border: 2px solid transparent;
       cursor: default;
       box-shadow: none;
       transform: none;
+
+      &::before {
+        border-color: transparent;
+      }
     }
 
     &.btn--dark-background {
@@ -291,12 +324,15 @@ $button-transition: all $time-s ease-in-out;
 }
 
 .btn--ghost {
-  border: 2px solid getShade($secondary-color, 110);
   font-size: 16px;
   padding: 0 $inline-m;
   color: getShade($secondary-color, 110);
   transition: $button-transition;
   height: 52px;
+
+  &::before {
+    border-color: getShade($secondary-color, 110);
+  }
 
   &:hover {
     transform: translateY(-1px);
@@ -315,11 +351,14 @@ $button-transition: all $time-s ease-in-out;
   &--white {
     background-color: transparent;
     color: $white;
-    border: 2px solid $white;
     
     &:hover {
       border-color: $white;
       background-color: inherit;
+    }
+
+    &::before {
+      border-color: $white;
     }
   }
 }

--- a/tests/unit/components/buttons/HdButton.spec.js
+++ b/tests/unit/components/buttons/HdButton.spec.js
@@ -3,6 +3,7 @@ import { wrapperFactoryBuilder } from 'tests/unit/helpers';
 import InlineSvg from 'vue-inline-svg';
 import HdButton, { TYPES } from '@/components/buttons/HdButton.vue';
 
+const ICON_BUTTON_CLASS = 'btn--icon-button';
 const ICON_CONTENT = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="222 126 53 53" width="50" height="50">
   <path class="color1" d="M272.48 137.62L258.61 150.5L244.75 141.58L254.65 126.73L272.48 137.62Z" fill="#1895FF"/>
   <path class="color2" d="M242.22 176.24L222.97 160.68L230.47 145.1L243.56 155.68L242.22 176.24Z" fill="#1C3553"/>
@@ -70,6 +71,21 @@ describe('HdButton', () => {
     });
     await wrapper.vm.$nextTick();
     expect(wrapper.find('svg').exists()).toBe(true);
+    expect(wrapper.classes()).not.toContain(ICON_BUTTON_CLASS);
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('can be used as an icon button', async () => {
+    const wrapper = wrapperBuilder({
+      props: {
+        iconSrc: 'fake/icon.svg',
+      },
+      slots: {
+        default: '',
+      },
+    });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.classes()).toContain(ICON_BUTTON_CLASS);
     expect(wrapper.html()).toMatchSnapshot();
   });
 

--- a/tests/unit/components/buttons/__snapshots__/HdButton.spec.js.snap
+++ b/tests/unit/components/buttons/__snapshots__/HdButton.spec.js.snap
@@ -1,43 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`HdButton can be used as an icon button 1`] = `
+<button class="btn btn--primary btn--icon-button"><span class="btn__icon"><svg height="100%" width="100%" viewBox="222 126 53 53" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
+  <path class="color1" d="M272.48 137.62L258.61 150.5L244.75 141.58L254.65 126.73L272.48 137.62Z" fill="#1895FF"></path>
+  <path class="color2" d="M242.22 176.24L222.97 160.68L230.47 145.1L243.56 155.68L242.22 176.24Z" fill="#1C3553"></path>
+</svg></span> <span class="btn__content"></span></button>
+`;
+
 exports[`HdButton should render component with \`btn\` class 1`] = `
 <button class="btn btn--primary">
-  <!----> <span>Button text</span></button>
+  <!----> <span class="btn__content"><span>Button text</span></span></button>
 `;
 
 exports[`HdButton should render component with btn--dark-background class if prop isInDarkBackground is true 1`] = `
 <button class="btn btn--primary btn--dark-background">
-  <!----> <span>Button text</span></button>
+  <!----> <span class="btn__content"><span>Button text</span></span></button>
 `;
 
 exports[`HdButton should render component with btn--flat class 1`] = `
 <button class="btn btn--flat">
-  <!----> <span>Button text</span></button>
+  <!----> <span class="btn__content"><span>Button text</span></span></button>
 `;
 
 exports[`HdButton should render component with btn--ghost class 1`] = `
 <button class="btn btn--ghost">
-  <!----> <span>Button text</span></button>
+  <!----> <span class="btn__content"><span>Button text</span></span></button>
 `;
 
 exports[`HdButton should render component with btn--primary class 1`] = `
 <button class="btn btn--primary">
-  <!----> <span>Button text</span></button>
+  <!----> <span class="btn__content"><span>Button text</span></span></button>
 `;
 
 exports[`HdButton should render component with btn--secondary class 1`] = `
 <button class="btn btn--secondary">
-  <!----> <span>Button text</span></button>
+  <!----> <span class="btn__content"><span>Button text</span></span></button>
 `;
 
 exports[`HdButton should render component with btn--tertiary class 1`] = `
 <button class="btn btn--tertiary">
-  <!----> <span>Button text</span></button>
+  <!----> <span class="btn__content"><span>Button text</span></span></button>
 `;
 
 exports[`HdButton should render the icon passed as prop 1`] = `
-<button class="btn btn--primary"><svg height="50" width="50" viewBox="222 126 53 53" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" class="btn__icon">
-    <path class="color1" d="M272.48 137.62L258.61 150.5L244.75 141.58L254.65 126.73L272.48 137.62Z" fill="#1895FF"></path>
-    <path class="color2" d="M242.22 176.24L222.97 160.68L230.47 145.1L243.56 155.68L242.22 176.24Z" fill="#1C3553"></path>
-  </svg> <span>Button text</span></button>
+<button class="btn btn--primary"><span class="btn__icon"><svg height="100%" width="100%" viewBox="222 126 53 53" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
+  <path class="color1" d="M272.48 137.62L258.61 150.5L244.75 141.58L254.65 126.73L272.48 137.62Z" fill="#1895FF"></path>
+  <path class="color2" d="M242.22 176.24L222.97 160.68L230.47 145.1L243.56 155.68L242.22 176.24Z" fill="#1C3553"></path>
+</svg></span> <span class="btn__content"><span>Button text</span></span></button>
 `;

--- a/tests/unit/components/form/__snapshots__/HdDynamicForm.spec.js.snap
+++ b/tests/unit/components/form/__snapshots__/HdDynamicForm.spec.js.snap
@@ -21,9 +21,9 @@ exports[`HdDynamicForm renders slots 1`] = `
     </div>
   </div>
   <div>The before button slot</div> <button class="dynamicForm__submit btn btn--primary">
-    <!---->
-    submit
-  </button>
+    <!----> <span class="btn__content">
+  submit
+  </span></button>
   <div>The after slot</div>
 </form>
 `;

--- a/tests/unit/setup.js
+++ b/tests/unit/setup.js
@@ -1,0 +1,10 @@
+// MutationObserver is used in HdButton
+/* eslint-disable */
+global.MutationObserver = class {
+  constructor() {}
+
+  disconnect() {}
+
+  observe() {}
+};
+ /* eslint-enable */


### PR DESCRIPTION
https://homeday.atlassian.net/browse/DS-115

~(This is still in discussion with the design team)~ Done!

- Adjusted the styles of the button in the case of icon only.
- The detection of the icon button case happens automatically thanks to MutationObserver, and it checks the content (text) of the button to decide. I went with this solution instead of a prop to avoid redundancy (we can know based on what we have, so no need for a flag).
- Wrapped HdIcon in a span to always make sure its space is reserved when the svg is being loaded, to avoid layout shifts.
- To avoid recalculating the padding and defining the border every time, I switched to using a pseudo-element (`::before`) to display the border of the buttons, and adjust just it's color based on the variant and the state.