### PR TITLE
[T] [DS-102] Use slots for nested components in HdTable

### DIFF
--- a/src/components/HdTable.vue
+++ b/src/components/HdTable.vue
@@ -8,7 +8,7 @@
     <tbody>
       <tr v-for="(tr, i) in body" :key="`row-${i}`">
         <td v-for="(value, i) in tr" :key="`cell-${i}`">
-          <slot :name="i" :value="value">{{ value }}</slot>
+          <slot :name="i" :value="value"><span>{{ value }}</span></slot>
         </td>
       </tr>
     </tbody>

--- a/src/components/HdTable.vue
+++ b/src/components/HdTable.vue
@@ -8,8 +8,7 @@
     <tbody>
       <tr v-for="(tr, i) in body" :key="`row-${i}`">
         <td v-for="(value, i) in tr" :key="`cell-${i}`">
-          <component v-if="isComponent(value)" :is="value.component" v-bind="value.props"></component>
-          <span v-else>{{ value }}</span>
+          <slot :name="i" :value="value">{{ value }}</slot>
         </td>
       </tr>
     </tbody>
@@ -40,11 +39,6 @@ export default {
     },
     noWrap: Boolean,
     fixed: Boolean,
-  },
-  methods: {
-    isComponent(value) {
-      return typeof value === 'object' && value.component !== undefined;
-    },
   },
 };
 </script>

--- a/src/components/HdTable.vue
+++ b/src/components/HdTable.vue
@@ -7,8 +7,8 @@
     </thead>
     <tbody>
       <tr v-for="(tr, i) in body" :key="`row-${i}`">
-        <td v-for="(value, i) in tr" :key="`cell-${i}`">
-          <slot :name="i" :value="value"><span>{{ value }}</span></slot>
+        <td v-for="(value, name) in tr" :key="`cell-${name}`">
+          <slot :name="name" :value="value"><span>{{ value }}</span></slot>
         </td>
       </tr>
     </tbody>

--- a/src/stories/HdTable.stories.js
+++ b/src/stories/HdTable.stories.js
@@ -50,7 +50,13 @@ storiesOf('Components/HdTable', module)
       HdTable,
       HdTagsList,
     },
-    template: '<hd-table :header="header" :body="body"></hd-table>',
+    template: `
+      <hd-table :header="header" :body="body">
+        <template #stars="{value}">
+          <HdTagsList :items="value"></HdTagsList>
+        </template>
+      </hd-table>
+    `,
     data() {
       return {
         header: MOVIES_TABLE.header,
@@ -60,12 +66,7 @@ storiesOf('Components/HdTable', module)
           title,
           year,
           rating,
-          theNameDoesntMatter: {
-            component: HdTagsList,
-            props: {
-              items: stars.split(','),
-            },
-          },
+          stars: stars.split(','),
         })),
       };
     },

--- a/tests/unit/components/HdTable.spec.js
+++ b/tests/unit/components/HdTable.spec.js
@@ -27,22 +27,4 @@ describe('HdTable', () => {
 
     expect(table.exists()).toBe(true);
   });
-
-  describe('methods', () => {
-    describe('isComponent', () => {
-      it('false for random object', () => {
-        const wrapper = wrapperBuilder();
-        const object = {};
-
-        expect(wrapper.vm.isComponent(object)).toBe(false);
-      });
-
-      it('true for object with property component', () => {
-        const wrapper = wrapperBuilder();
-        const object = { component: HdTable };
-
-        expect(wrapper.vm.isComponent(object)).toBe(true);
-      });
-    });
-  });
 });


### PR DESCRIPTION
[DS-102](https://homeday.atlassian.net/browse/DS-102)

Instead of passing the object with component definition to the table through body props, a named slot template has to be defined inside the parent component - with property key as a name (depending on which column we want to have a different layout for):

```
<hd-table :header="header" :body="body">
  <template #stars="{value}">
    <HdTagsList :items="value"></HdTagsList>
  </template>
</hd-table>
```