### PR TITLE
[T] Update HdRadio component with the design system

### DIFF
--- a/src/components/form/HdRadio.vue
+++ b/src/components/form/HdRadio.vue
@@ -279,8 +279,6 @@ export default {
 
   position: relative;
 
-  transition: outline $time-s ease-in-out;
-
   &:not(:first-of-type) {
     margin-left: $inline-m;
   }

--- a/src/stories/HdRadio.stories.js
+++ b/src/stories/HdRadio.stories.js
@@ -1,38 +1,190 @@
-/* eslint-disable import/no-extraneous-dependencies, no-console */
-import { storiesOf } from '@storybook/vue';
-import { action } from '@storybook/addon-actions';
-import { HdRadio } from 'homeday-blocks';
+import { HdRadio, HdButton } from 'homeday-blocks';
 import ITEMS from './mocks/FORM_ITEMS';
 
-storiesOf('Components/Form/HdRadio', module)
-  .add('required', () => ({
-    components: { HdRadio },
-    template: `
-      <div>
-        <HdRadio
-          v-model="value"
-          ref="myRadio"
-          :items="ITEMS"
-          :required="true"
-          name="test"
-          label="Label"
-        />
-        <button @click="validate">
-          Validate (Check action logger)
-        </button>
-      </div>
-    `,
-    data() {
-      return {
-        value: '',
-        ITEMS,
-      };
+export default {
+  title: 'Components/Form/HdRadio',
+  component: HdRadio,
+  argTypes: {
+    disabled: {
+      control: { type: 'boolean' },
     },
-    watch: {
-      value(value) {
-        action('input')(value);
+    items: {
+      control: { type: 'object' },
+    },
+    lang: {
+      control: { type: 'select', options: ['de', 'en'] },
+    },
+    required: {
+      control: { type: 'boolean' },
+    },
+    vertical: {
+      control: { type: 'boolean' },
+    },
+    texts: {
+      description: `For now the only text used is the required validation field. <code lang="javascript">${JSON.stringify({
+        FORM: {
+          VALIDATION: {
+            REQUIRED: 'Dies ist ein Pflichtfeld.',
+          },
+        },
+      })}</code>`,
+      control: {
+        type: 'object',
       },
     },
+  },
+  args: {
+    disabled: false,
+    items: ITEMS,
+    lang: 'de',
+    name: 'my-radio',
+    required: false,
+    vertical: false,
+    texts: null,
+    value: null,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<template>
+  <HdRadio
+    v-model="myDataProperty"
+    :name="name"
+    :items="items"
+    :required="required"
+    :vertical="vertical"
+    :lang="lang"
+    :disabled="disabled"
+    :texts="texts"
+  />
+</template>
+        `,
+      },
+    },
+  },
+};
+
+const Template = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { HdRadio, HdButton },
+  data: () => ({
+    selectedValue: args.value,
+  }),
+  template: `
+    <div>
+      <HdRadio
+        v-model="selectedValue"
+        :name="name"
+        :items="items"
+        :required="required"
+        :vertical="vertical"
+        :lang="lang"
+        :disabled="disabled"
+        :texts="texts"
+        ref="myRadio"
+        />
+
+      <HdButton
+        modifier="secondary"
+        :style="{ marginTop: '2rem', marginRight: '0.5rem' }"
+        @click.native="validate"
+      >
+        Submit
+      </HdButton>
+
+      <HdButton modifier="tertiary" @click.native="selectedValue = null">
+        Reset form
+      </HdButton>
+    </div>
+  `,
+  methods: {
+    validate() {
+      const isValid = this.$refs.myRadio.validate();
+
+      if (!isValid) {
+        console.log('Not Valid');
+      } else {
+        console.log(`Valid! You selected: ${this.selectedValue}`);
+      }
+    },
+  },
+});
+
+export const Default = Template.bind({});
+
+export const Preselected = Template.bind({});
+Preselected.args = {
+  value: 'daenerys',
+};
+Preselected.parameters = {
+  docs: {
+    description: {
+      story: 'To pre-select a value, just set an "item" prop in the `v-model`.',
+    },
+    source: {
+      code: `
+<template>
+  <HdRadio
+    v-model="myDataProperty"
+    :name="name"
+    :items="items"
+  />
+
+  <HdButton @click.native="validate">Submit</HdButton>
+</template>
+
+<script>
+  export default {
+    data: () => ({
+      myDataProperty: 'option1'
+    }),
+    computed: {
+      items() {
+        return [
+          { label: 'Option 1', value: 'option1' },
+          { label: 'Option 2', value: 'option2' },
+        ]
+      },
+    },
+  }
+</script>
+      `,
+    },
+  },
+};
+
+export const Validation = Template.bind({});
+Validation.args = {
+  required: true,
+};
+Validation.parameters = {
+  docs: {
+    description: {
+      story: `
+You must add the \`required\` prop in order to enable validation.
+
+You can manually trigger the validation using a \`ref\` in the \`HdRadio\` component and triggering the method \`this.$refs.myRadioRef.validate()\`.
+
+Check the code bellow for a better example.
+      `,
+    },
+    source: {
+      code: `
+<template>
+  <HdRadio
+    v-model="myDataProperty"
+    :name="name"
+    :items="items"
+    required
+    ref="myRadio"
+  />
+
+  <HdButton @click.native="validate">Submit</HdButton>
+</template>
+
+<script>
+  export default {
     methods: {
       validate() {
         const isValid = this.$refs.myRadio.validate();
@@ -40,80 +192,13 @@ storiesOf('Components/Form/HdRadio', module)
         if (!isValid) {
           console.log('Not Valid');
         } else {
-          console.log(`Valid! You selected: ${this.value}`);
+          console.log('Valid');
         }
       },
     },
-  }), { percy: { skip: true } })
-  .add('preselected', () => ({
-    components: { HdRadio },
-    template: `
-      <div>
-        <HdRadio
-          v-model="value"
-          ref="myRadio"
-          :items="ITEMS"
-          name="test"
-          label="Label"
-        />
-      </div>
-    `,
-    data() {
-      return {
-        value: ITEMS[2].value,
-        ITEMS,
-      };
+  }
+</script>
+      `,
     },
-    watch: {
-      value(value) {
-        action('input')(value);
-      },
-    },
-  }))
-  .add('vertical', () => ({
-    components: { HdRadio },
-    template: `
-      <div>
-        <HdRadio
-          v-model="value"
-          ref="myRadio"
-          :items="ITEMS"
-          :vertical="true"
-          name="test"
-          label="Label"
-        />
-      </div>
-    `,
-    data() {
-      return {
-        value: '',
-        ITEMS,
-      };
-    },
-    watch: {
-      value(value) {
-        action('input')(value);
-      },
-    },
-  }))
-  .add('disabled', () => ({
-    components: { HdRadio },
-    template: `
-      <div>
-        <HdRadio
-          v-model="value"
-          ref="myRadio"
-          :items="ITEMS"
-          :disabled="true"
-          name="test"
-          label="Label"
-        />
-      </div>
-    `,
-    data() {
-      return {
-        value: ITEMS[0].value,
-        ITEMS,
-      };
-    },
-  }));
+  },
+};

--- a/tests/unit/components/form/HdRadio.spec.js
+++ b/tests/unit/components/form/HdRadio.spec.js
@@ -7,8 +7,8 @@ import HdRadio from '@/components/form/HdRadio.vue';
 import ITEMS from '@/stories/mocks/FORM_ITEMS';
 
 // list of selectors we depend on
-const SELECTED_ITEM_SELECTOR = '.isSelected';
-const VERTICAL_CLASSNAME = 'radio-wrapper--vertical';
+const SELECTED_ITEM_SELECTOR = '.radio--selected';
+const VERTICAL_ITEM_SELECTOR = '.radio-wrapper--vertical';
 const ITEMS_SELECTOR = { ref: 'items' };
 
 const wrapperBuilder = wrapperFactoryBuilder(HdRadio, {
@@ -102,7 +102,7 @@ describe('HdRadio', () => {
       },
     });
 
-    expect(wrapper.classes()).toContain(VERTICAL_CLASSNAME);
+    expect(wrapper.find(VERTICAL_ITEM_SELECTOR).exists()).toBe(true);
   });
 
   it('validates requiredness', () => {

--- a/tests/unit/components/form/__snapshots__/HdRadio.spec.js.snap
+++ b/tests/unit/components/form/__snapshots__/HdRadio.spec.js.snap
@@ -1,27 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HdRadio is rendered as expected 1`] = `
-<section class="radio-wrapper"><label id="testRadio--label" tabindex="-1" class="radio-wrapper__label">test radio label</label>
-  <div id="testRadio" aria-labelledby="testRadio--label" role="radiogroup" class="radio-wrapper__items">
-    <div aria-checked="false" tabindex="0" role="radio" class="radio"><input name="testRadio" type="radio" class="radio__input" value="jon">
-      <div class="radio__circle"></div>
-      <p class="radio__label">Jon "Snow"</p>
+<section label="test radio label">
+  <div role="radiogroup" class="radio-wrapper">
+    <div aria-checked="false" tabindex="0" class="radio"><input id="testRadio-jon" name="testRadio-jon" type="radio" value="jon">
+      <div class="radio__circle"></div> <label for="testRadio-jon" class="radio__label">
+        Jon "Snow"
+      </label>
     </div>
-    <div aria-checked="false" tabindex="-1" role="radio" class="radio"><input name="testRadio" type="radio" class="radio__input" value="daenerys">
-      <div class="radio__circle"></div>
-      <p class="radio__label">Daenerys</p>
+    <div aria-checked="false" tabindex="-1" class="radio"><input id="testRadio-daenerys" name="testRadio-daenerys" type="radio" value="daenerys">
+      <div class="radio__circle"></div> <label for="testRadio-daenerys" class="radio__label">
+        Daenerys
+      </label>
     </div>
-    <div aria-checked="false" tabindex="-1" role="radio" class="radio"><input name="testRadio" type="radio" class="radio__input" value="nightKing">
-      <div class="radio__circle"></div>
-      <p class="radio__label">The Night King</p>
+    <div aria-checked="false" tabindex="-1" class="radio"><input id="testRadio-nightKing" name="testRadio-nightKing" type="radio" value="nightKing">
+      <div class="radio__circle"></div> <label for="testRadio-nightKing" class="radio__label">
+        The Night King
+      </label>
     </div>
-    <div aria-checked="false" tabindex="-1" role="radio" class="radio"><input name="testRadio" type="radio" class="radio__input" value="arya">
-      <div class="radio__circle"></div>
-      <p class="radio__label">Arya</p>
+    <div aria-checked="false" tabindex="-1" class="radio"><input id="testRadio-arya" name="testRadio-arya" type="radio" value="arya">
+      <div class="radio__circle"></div> <label for="testRadio-arya" class="radio__label">
+        Arya
+      </label>
     </div>
-    <div aria-checked="false" tabindex="-1" role="radio" class="radio"><input name="testRadio" type="radio" class="radio__input" value="cersei">
-      <div class="radio__circle"></div>
-      <p class="radio__label">Cersei</p>
+    <div aria-checked="false" tabindex="-1" class="radio"><input id="testRadio-cersei" name="testRadio-cersei" type="radio" value="cersei">
+      <div class="radio__circle"></div> <label for="testRadio-cersei" class="radio__label">
+        Cersei
+      </label>
     </div>
   </div>
   <!---->


### PR DESCRIPTION
https://homeday.atlassian.net/browse/DS-108

In this PR:
- Refactor the HdRadio component to match the design system
- Fix CSS order in the component to avoid having complex selectors
  - E.g: `.radio:not(:focus):not(#{$r}--disabled) .radio__circle` was removed just by reordering the `disabled state`  classes
- Removed the `label` prop, it was not being used in any project that we have at Homeday (This was confirmed with Magda)
- Update the `HdRadio` javascript to "match" @ilyasmez [pull request](https://github.com/homeday-de/homeday-blocks/pull/559)
- Updated `HdRadio` stories

You can see a preview of the changes here:
https://blocks-storybook-6.netlify.app/?path=/story/components-form-hdradio--default