### PR TITLE
[B] Skip the PR deployment for forks

### DIFF
--- a/.github/workflows/deploy-pr-to-s3.yml
+++ b/.github/workflows/deploy-pr-to-s3.yml
@@ -38,7 +38,6 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           SOURCE_DIR: 'dist'
-          DEST_DIR: '${{ env.REPO_NAME }}/${{ env.PR_NUMBER }}'
 
       - name: Add comment
         uses: marocchino/sticky-pull-request-comment@v1

--- a/.github/workflows/deploy-pr-to-s3.yml
+++ b/.github/workflows/deploy-pr-to-s3.yml
@@ -4,10 +4,11 @@ on: [pull_request]
 env:
   PR_NUMBER: ${{ github.event.pull_request.number }}
   REPO_NAME: ${{ github.event.repository.name }}
+  hasTheNeededSecrets: ${{ secrets.AWS_S3_PR_DEPLOYMENT_BUCKET && secrets.AWS_ACCESS_KEY_ID && secrets.AWS_SECRET_ACCESS_KEY }}
 
 jobs:
   deploy-to-s3:
-    if: secrets.AWS_S3_PR_DEPLOYMENT_BUCKET && secrets.AWS_ACCESS_KEY_ID && secrets.AWS_SECRET_ACCESS_KEY
+    if: env.hasTheNeededSecrets
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-pr-to-s3.yml
+++ b/.github/workflows/deploy-pr-to-s3.yml
@@ -4,11 +4,10 @@ on: [pull_request]
 env:
   PR_NUMBER: ${{ github.event.pull_request.number }}
   REPO_NAME: ${{ github.event.repository.name }}
-  hasTheNeededSecrets: ${{ secrets.AWS_S3_PR_DEPLOYMENT_BUCKET && secrets.AWS_ACCESS_KEY_ID && secrets.AWS_SECRET_ACCESS_KEY }}
 
 jobs:
   deploy-to-s3:
-    if: env.hasTheNeededSecrets
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-pr-to-s3.yml
+++ b/.github/workflows/deploy-pr-to-s3.yml
@@ -7,6 +7,7 @@ env:
 
 jobs:
   deploy-to-s3:
+    if: secrets.AWS_S3_PR_DEPLOYMENT_BUCKET && secrets.AWS_ACCESS_KEY_ID && secrets.AWS_SECRET_ACCESS_KEY
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
To be able to use the build per PR features, make sure to open the PR from a branch in the same repo (not a fork), the same way we do for the other projects.

~If for some reason you want to use your fork, you'll have to add the necessary secrets to your fork (reach out for more details).~
_Update:_ After double-checking the Github Action docs, I found out that it's not possible to use `secrets` nor `env` in the if statement of a job, so that's a deal breaking, so I went for disabling the whole job if the head branch is from a fork.


**This PR**:
- adds a check if the head is from a fork and skips the whole deployment job if it's true;
- fixes the build destination path.