### PR TITLE
[B] Bring back the error styles to HdCheckbox

### DIFF
--- a/src/components/form/HdCheckbox.vue
+++ b/src/components/form/HdCheckbox.vue
@@ -302,6 +302,13 @@ export default {
     }
   }
   &__error {
+    @include font('text-xxsmall');
+    position: absolute;
+    top: calc(100% + #{$inline-xs});
+    margin-left: $inline-m;
+    color: $error-color;
+    display: none;
+
     #{$c}.hasError & {
       display: block;
     }


### PR DESCRIPTION
The previous [form components refactoring](https://github.com/homeday-de/homeday-blocks/pull/559) didn't include HdCheckbox as we have a ticket for that (@leandroinacio is taking care of it), and that broke the error styles of that component.
This PR just brings back the old styles (without following the new design or using `FieldBase`), so we don't have it broken and can publish a new version whenever we want.

**Before the fix:**
<img width="304" alt="Screen Shot 2020-10-16 at 4 55 58 PM" src="https://user-images.githubusercontent.com/30146019/96274145-7c6c0400-0fd0-11eb-8333-4c47e0b108e9.png">

**After the fix:**
<img width="285" alt="Screen Shot 2020-10-16 at 4 55 18 PM" src="https://user-images.githubusercontent.com/30146019/96274154-7e35c780-0fd0-11eb-96bb-8833c6758eb2.png">
