### PR TITLE
Fix isAvailable typo in HdTimeslots

### DIFF
--- a/src/components/HdTimeslots.vue
+++ b/src/components/HdTimeslots.vue
@@ -9,7 +9,7 @@
         <div class="timeslots__slots" :key="currentPageIndex">
           <span
             class="timeslots__slot"
-            :class="{'timeslots__slot--isUnavailable': timeslot.isAvialable === false, 'timeslots__slot--isSelected': timeslot.time === selectedTime}"
+            :class="{'timeslots__slot--isUnavailable': timeslot.isAvailable === false, 'timeslots__slot--isSelected': timeslot.time === selectedTime}"
             v-for="timeslot in activeTimeslotPage"
             :key="timeslot.time"
             @click="selectTimeslot(timeslot)"
@@ -77,7 +77,7 @@ export default {
     selectFirstAvialable() {
       this.currentPageIndex = 0;
       const firstAvialableTimeslot = this.activeTimeslotPage
-        .find(timeslot => timeslot.isAvialable);
+        .find(timeslot => timeslot.isAvailable);
 
       this.selectTimeslot(firstAvialableTimeslot);
     },
@@ -91,7 +91,7 @@ export default {
       this.currentPageIndex += indexMod;
     },
     selectTimeslot(timeslot) {
-      if (timeslot && timeslot.isAvialable) this.selectedTime = timeslot.time;
+      if (timeslot && timeslot.isAvailable) this.selectedTime = timeslot.time;
     },
   },
   watch: {

--- a/src/stories/mocks/generateTimeSlots.js
+++ b/src/stories/mocks/generateTimeSlots.js
@@ -6,7 +6,6 @@ export default (endStartDeltaMins, duration) => range(1, (endStartDeltaMins / du
     const mins = duration * slot;
     // We have to make sure to also set the seconds and milliseconds to 0
     date.setMinutes(mins, 0, 0);
-    const isAvialable = true;
 
     const hours = date.getHours();
     // Pad minutes with trailing zero
@@ -14,6 +13,6 @@ export default (endStartDeltaMins, duration) => range(1, (endStartDeltaMins / du
     const time = `${hours}:${minutes}`;
     return {
       time,
-      isAvialable,
+      isAvailable: true,
     };
   });


### PR DESCRIPTION
In this PR:

- Fix typo in `HdTimeslots` component from `isAvialable` to `isAvailable`