### PR TITLE
[T] Change calendar component to support disabled dates

### DIFF
--- a/src/components/HdCalendar.vue
+++ b/src/components/HdCalendar.vue
@@ -81,7 +81,7 @@ export default {
       // Check if passed array contains only valid dates
       validator: dates => dates.filter(d => typeof d.getMonth === 'function').length === dates.length,
     },
-    disabledIndexes: {
+    disabledDates: {
       type: Array,
       default() {
         return [];
@@ -110,7 +110,7 @@ export default {
     // Slice dates array into week chunks
     this.availableWeeks = chunk(this.dates, WEEK_DAYS);
 
-    this.selectFirstAvialable();
+    this.selectFirstAvailable();
   },
   computed: {
     displayedWeeks() {
@@ -121,12 +121,12 @@ export default {
     },
   },
   watch: {
-    disabledIndexes() {
-      this.selectFirstAvialable();
+    disabledDates() {
+      this.selectFirstAvailable();
     },
   },
   methods: {
-    selectFirstAvialable() {
+    selectFirstAvailable() {
       const firstAvialableDay = this.displayedWeeks[0]
         .find(day => this.isDisabled(day) === false);
 
@@ -146,19 +146,11 @@ export default {
       setTimeout(() => {
         this.selectedWeekIndexTail += indexDiff;
         this.animateCalendar = !this.animateCalendar;
-        this.selectFirstAvialable();
+        this.selectFirstAvailable();
       }, 0);
     },
     isDisabled(date) {
-      const dateIndex = this.dates.indexOf(date);
-      const isDisabledIndex = this.disabledIndexes.indexOf(dateIndex) !== -1;
-
-      return isDisabledIndex || this.isWeekend(date);
-    },
-    isWeekend(date) {
-      // IE's Date.toLocaleString is includes left-to-right marks in it (U+200E), so we have to trim that
-      const dateDayString = date.toLocaleString('en-GB', { weekday: 'short' }).replace(/[^ -~]/g, '');
-      return dateDayString === 'Sun' || dateDayString === 'Sat';
+      return this.disabledDates.indexOf(date) !== -1;
     },
     selectDate(date) {
       if (this.isDisabled(date)) return;

--- a/tests/unit/components/HdCalendar.spec.js
+++ b/tests/unit/components/HdCalendar.spec.js
@@ -61,17 +61,17 @@ describe('HdCalendar', () => {
   });
 
   it('when the disabled indexes are updated, the first available date is selected', () => {
-    const selectFirstAvialableMock = jest.fn();
+    const selectFirstAvailableMock = jest.fn();
     const wrapper = wrapperBuilder({
       methods: {
-        selectFirstAvialable: selectFirstAvialableMock,
+        selectFirstAvailable: selectFirstAvailableMock,
       },
     });
 
     wrapper.setProps({
-      disabledIndexes: [],
+      disabledDates: [],
     });
 
-    expect(selectFirstAvialableMock).toHaveBeenCalled();
+    expect(selectFirstAvailableMock).toHaveBeenCalled();
   });
 });

--- a/tests/unit/components/__snapshots__/HdCalendar.spec.js.snap
+++ b/tests/unit/components/__snapshots__/HdCalendar.spec.js.snap
@@ -29,10 +29,10 @@ exports[`HdCalendar renders component 1`] = `
             <div class="calendar__date calendar__row__item">
               8
             </div>
-            <div class="calendar__date calendar__row__item calendar__date--disabled">
+            <div class="calendar__date calendar__row__item">
               9
             </div>
-            <div class="calendar__date calendar__row__item calendar__date--disabled">
+            <div class="calendar__date calendar__row__item">
               10
             </div>
             <div class="calendar__date calendar__row__item">
@@ -52,10 +52,10 @@ exports[`HdCalendar renders component 1`] = `
             <div class="calendar__date calendar__row__item">
               15
             </div>
-            <div class="calendar__date calendar__row__item calendar__date--disabled">
+            <div class="calendar__date calendar__row__item">
               16
             </div>
-            <div class="calendar__date calendar__row__item calendar__date--disabled">
+            <div class="calendar__date calendar__row__item">
               17
             </div>
             <div class="calendar__date calendar__row__item">


### PR DESCRIPTION
In this PR:

- Change `HdCalendar` component to enable all days
- Rename prop `disabledIndexes` to `disabledDates`

All those changes are required for the ticket:
https://homeday.atlassian.net/browse/REAL-2412

And the exposé preparation module is the only one using the `HdCalendar` component for now.
This component will face a massive refactor afterwards to be completely usable.