### PR TITLE
[B] Fix HdInput component to not clear on enter

### DIFF
--- a/src/components/form/TextFieldBase.vue
+++ b/src/components/form/TextFieldBase.vue
@@ -21,6 +21,7 @@
       />
       <button
         v-else-if="isClearButtonVisible"
+        type="button"
         class="text-field__clear-button"
         @click="$emit('clear-click')"
         @focus="onClearButtonFocus"


### PR DESCRIPTION
In this PR:

- Fix HdInput bug
  - Since we don't specify the clear button type, when the input is in a form if a user hits enter, the clear button is triggered instead of the submit

![fbbayg4tmjx0fum22wlm](https://user-images.githubusercontent.com/1855125/98251562-23f9a800-1f79-11eb-833e-0dce6e77d95a.gif)

What is happening:
- When we don't specify a `type="button"` in a `<button>` tag, when the user hits enter, it will "click" the closest button AND submit the form
- If we have a form like this:

``` html
<form>
  <div>
    <input type="text">
    <button type="button" onclick="alert('BLA')">BLA</button> 
    <button onclick="alert('CLEARED')">CLEAR</button> 
  </div>
  
  <button type="submit">Submit</button>
</form>
```

- When a user fills the input and press `enter`, the alert `CLEARED` will be displayed
- And the form would be submitted
