### PR TITLE
[RELEASE] Fix HdInput component to not clear on enter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homeday-blocks",
-  "version": "13.2.0",
+  "version": "14.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homeday-blocks",
-  "version": "14.0.0",
+  "version": "14.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homeday-blocks",
-  "version": "14.0.0",
+  "version": "14.0.1",
   "description": "A Vue component library built by Homeday's frontend team.",
   "main": "main.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homeday-blocks",
-  "version": "13.2.0",
+  "version": "14.0.0",
   "description": "A Vue component library built by Homeday's frontend team.",
   "main": "main.js",
   "repository": {

--- a/src/components/form/TextFieldBase.vue
+++ b/src/components/form/TextFieldBase.vue
@@ -21,6 +21,7 @@
       />
       <button
         v-else-if="isClearButtonVisible"
+        type="button"
         class="text-field__clear-button"
         @click="$emit('clear-click')"
         @focus="onClearButtonFocus"


### PR DESCRIPTION
In this release:

- Fix HdInput bug
  - Since we don't specify the clear button type, when the input is in a form if a user hits enter, the clear button is triggered instead of the submit

![fbbayg4tmjx0fum22wlm](https://user-images.githubusercontent.com/1855125/98251562-23f9a800-1f79-11eb-833e-0dce6e77d95a.gif)

For more details, check [this link](https://github.com/homeday-de/homeday-blocks/pull/603)
