### PR TITLE
[B][CE-2164] HDInput Active Statement 

### DIFF
--- a/src/components/form/TextFieldBase.vue
+++ b/src/components/form/TextFieldBase.vue
@@ -78,7 +78,7 @@ export default {
   },
   computed: {
     isClearButtonVisible() {
-      return this.$attrs.filled && this.hasFocus;
+      return this.$attrs.filled && this.hasError && this.hasFocus;
     },
     isErrorStatusVisible() {
       return this.hasError && !this.$attrs.active;


### PR DESCRIPTION
Hey All!

We were discussing the new Input Reset Button feature of homeday-blocks with @metal-gogo and we realized that there is a small missing point regarding input statements on the implementation. This is our meeting’s outcome with @metal-gogo 

* Implementation says the clear button should be shown when the user starts to type something on the input. (https://prnt.sc/vhi0tg).
* The design indicates that the clear button should be shown when there is an error and the input is focused (https://homeday.zeroheight.com/styleguide/s/22414/p/601cda-inputs)

At the moment, we are showing the clear button whenever the field doesn’t show a validation check, and the field is focused. We must show the clear button only when there is an error, and the input is focused. :warning: