### PR TITLE
🐛 (Elevations): make sure to create the elevations from 0 to 10

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -124,7 +124,7 @@ $font-list: ('headline', 'headline'),
 
 
 /** Elevation **/
-@for $level from 0 through length($elevation-levels) - 1 {
+@for $level from 0 to length($elevation-levels) {
   .elevation-#{$level} {
     @include elevation($level);
   }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -124,7 +124,7 @@ $font-list: ('headline', 'headline'),
 
 
 /** Elevation **/
-@for $level from 0 through length($elevation-levels) {
+@for $level from 0 through length($elevation-levels) - 1 {
   .elevation-#{$level} {
     @include elevation($level);
   }


### PR DESCRIPTION
Currently while building it prompts the following warning:

<img width="710" alt="Screen Shot 2020-11-12 at 8 07 41" src="https://user-images.githubusercontent.com/7268262/98950062-251d5e80-24be-11eb-86b3-c50127015b94.png">

That is because we are trying to use elevations from `0` to `11`.