### PR TITLE
[T] Reduce the typography warning noise

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homeday-blocks",
-  "version": "14.2.0",
+  "version": "14.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homeday-blocks",
-  "version": "14.2.0",
+  "version": "14.2.1",
   "description": "A Vue component library built by Homeday's frontend team.",
   "main": "main.js",
   "repository": {

--- a/src/styles/deprecated_font.scss
+++ b/src/styles/deprecated_font.scss
@@ -1,6 +1,4 @@
 @mixin deprecated_font($style) {
-  @warn "Please use the new 'font' mixin in the typography style sheet. You can read more about it on https://blocks.homeday.dev/?path=/story/typography-typography-text-variants--font-sizes";
-
   @if ($style == 'headline') {
     font-family: $font-primary;
     color: inherit;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -3,6 +3,8 @@
 @import './typography';
 @import './_variables';
 
+@warn "Please use the new DS typography, the old one will be removed in the next major release. You can read more about it on https://bit.ly/3adOqgw. Ignore this warning if already done.";
+
 * {
   box-sizing: border-box;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
The warning was showing for every case `font()` is used, and you can imagine how many times it's currently used in big projects.
That was causing too much noise and made our logs very long which was causing Travis builds to fail due to the 4mb logs limit.
I tried to suppress the warnings on the projects level, but sass-loader doesn't support passing the `quiet` flag :/

I went for a softer version now. And we can go back to the aggressive warning after giving the developers some time to migrate to the new typography.

I wish Sass had a `@warn-once` rule .
