### PR TITLE
[T] Add hasChanged prop to HdForm to make tracking changes easier

### DIFF
--- a/src/components/form/HdForm.vue
+++ b/src/components/form/HdForm.vue
@@ -24,10 +24,6 @@ export default {
       type: Boolean,
       default: false,
     },
-    hasChanged: {
-      type: Boolean,
-      default: null,
-    },
   },
   data() {
     return {
@@ -42,14 +38,15 @@ export default {
   },
   created() {
     this.initialFormData = _cloneDeep(this.getFormData());
-
-    if (!_isNil(this.hasChanged)) {
-      this.$watch('fieldsValues', () => {
+  },
+  watch: {
+    fieldsValues() {
+      if (this.$listeners.hasChanged) {
         const formData = formatNestedData(this.getFormData());
         const hasChanged = !_isEqual(formData, this.initialFormData);
-        this.$emit('update:hasChanged', hasChanged);
-      });
-    }
+        this.$emit('hasChanged', hasChanged);
+      }
+    },
   },
   methods: {
     getFormData() {

--- a/src/components/form/HdForm.vue
+++ b/src/components/form/HdForm.vue
@@ -42,7 +42,8 @@ export default {
     if (this.$listeners.hasChanged) {
       this.$watch('fieldsValues', () => {
         const formData = formatNestedData(this.getFormData());
-        const hasChanged = !_isEqual(formData, this.initialFormData);
+        const initialFormData = formatNestedData(this.initialFormData);
+        const hasChanged = !_isEqual(formData, initialFormData);
         this.$emit('hasChanged', hasChanged);
       });
     }

--- a/src/components/form/HdForm.vue
+++ b/src/components/form/HdForm.vue
@@ -24,6 +24,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    hasChanged: {
+      type: Boolean,
+      default: null,
+    },
   },
   data() {
     return {
@@ -31,8 +35,22 @@ export default {
       fields: [],
     };
   },
+  computed: {
+    fieldsValues() {
+      return this.fields.map(field => field.value);
+    },
+  },
   created() {
     this.initialFormData = _cloneDeep(this.getFormData());
+  },
+  watch: {
+    fieldsValues() {
+      if (!_isNil(this.hasChanged)) {
+        const formData = formatNestedData(this.getFormData());
+        const hasChanged = !_isEqual(formData, this.initialFormData);
+        this.$emit('update:hasChanged', hasChanged);
+      }
+    },
   },
   methods: {
     getFormData() {

--- a/src/components/form/HdForm.vue
+++ b/src/components/form/HdForm.vue
@@ -38,15 +38,14 @@ export default {
   },
   created() {
     this.initialFormData = _cloneDeep(this.getFormData());
-
-    if (this.$listeners.hasChanged) {
-      this.$watch('fieldsValues', () => {
-        const formData = formatNestedData(this.getFormData());
-        const initialFormData = formatNestedData(this.initialFormData);
-        const hasChanged = !_isEqual(formData, initialFormData);
-        this.$emit('hasChanged', hasChanged);
-      });
-    }
+  },
+  watch: {
+    fieldsValues() {
+      const formData = formatNestedData(this.getFormData());
+      const initialFormData = formatNestedData(this.initialFormData);
+      const hasChanged = !_isEqual(formData, initialFormData);
+      this.$emit('change', hasChanged);
+    },
   },
   methods: {
     getFormData() {

--- a/src/components/form/HdForm.vue
+++ b/src/components/form/HdForm.vue
@@ -42,15 +42,14 @@ export default {
   },
   created() {
     this.initialFormData = _cloneDeep(this.getFormData());
-  },
-  watch: {
-    fieldsValues() {
-      if (!_isNil(this.hasChanged)) {
+
+    if (!_isNil(this.hasChanged)) {
+      this.$watch('fieldsValues', () => {
         const formData = formatNestedData(this.getFormData());
         const hasChanged = !_isEqual(formData, this.initialFormData);
         this.$emit('update:hasChanged', hasChanged);
-      }
-    },
+      });
+    }
   },
   methods: {
     getFormData() {

--- a/src/components/form/HdForm.vue
+++ b/src/components/form/HdForm.vue
@@ -38,15 +38,14 @@ export default {
   },
   created() {
     this.initialFormData = _cloneDeep(this.getFormData());
-  },
-  watch: {
-    fieldsValues() {
-      if (this.$listeners.hasChanged) {
+
+    if (this.$listeners.hasChanged) {
+      this.$watch('fieldsValues', () => {
         const formData = formatNestedData(this.getFormData());
         const hasChanged = !_isEqual(formData, this.initialFormData);
         this.$emit('hasChanged', hasChanged);
-      }
-    },
+      });
+    }
   },
   methods: {
     getFormData() {

--- a/src/components/form/HdForm.vue
+++ b/src/components/form/HdForm.vue
@@ -44,7 +44,7 @@ export default {
       const formData = formatNestedData(this.getFormData());
       const initialFormData = formatNestedData(this.initialFormData);
       const hasChanged = !_isEqual(formData, initialFormData);
-      this.$emit('change', hasChanged);
+      this.$emit('change', { hasChanged });
     },
   },
   methods: {

--- a/src/stories/HdForm.stories.js
+++ b/src/stories/HdForm.stories.js
@@ -30,7 +30,7 @@ const Template = (args, { argTypes }) => ({
   template: `
     <HdForm
       @submit="onSubmit"
-      @has-changed="onFormChange"
+      @hasChanged="onFormChange"
       v-bind="$props"
     >
       <h2><b>Personal data:</b></h2>
@@ -76,6 +76,7 @@ const Template = (args, { argTypes }) => ({
     },
     onFormChange(val) {
       this.hasFormChanged = val;
+      console.log('hasChanged', val);
     },
   },
 });

--- a/src/stories/HdForm.stories.js
+++ b/src/stories/HdForm.stories.js
@@ -13,10 +13,6 @@ export default {
       control: 'boolean',
       description: 'If set to true and the form is invalid, the window will scroll to the first invalid field when the form is submitted',
     },
-    hasChanged: {
-      control: 'boolean',
-      description: 'If passed to the component, the watcher for form changes is added (compares changes with initial values) and event to update hasChanged is emitted',
-    },
   },
   args: {
     scrollToInvalidField: false,
@@ -34,7 +30,7 @@ const Template = (args, { argTypes }) => ({
   template: `
     <HdForm
       @submit="onSubmit"
-      :has-changed.sync="hasFormChanged"
+      @has-changed="onFormChange"
       v-bind="$props"
     >
       <h2><b>Personal data:</b></h2>
@@ -65,7 +61,7 @@ const Template = (args, { argTypes }) => ({
       age: 45,
       address: {},
       submittedDataString: '',
-      hasFormChanged: false,
+      hasFormChanged: null,
     };
   },
   methods: {
@@ -77,6 +73,9 @@ const Template = (args, { argTypes }) => ({
         '...': 'the other Vue component attributes were suppressed as Storybook struggles to stringify objects with circular references',
       }));
       console.log('submitted', params);
+    },
+    onFormChange(val) {
+      this.hasFormChanged = val;
     },
   },
 });

--- a/src/stories/HdForm.stories.js
+++ b/src/stories/HdForm.stories.js
@@ -13,6 +13,10 @@ export default {
       control: 'boolean',
       description: 'If set to true and the form is invalid, the window will scroll to the first invalid field when the form is submitted',
     },
+    hasChanged: {
+      control: 'boolean',
+      description: 'If passed to the component, the watcher for form changes is added (compares changes with initial values) and event to update hasChanged is emitted',
+    },
   },
   args: {
     scrollToInvalidField: false,
@@ -30,6 +34,7 @@ const Template = (args, { argTypes }) => ({
   template: `
     <HdForm
       @submit="onSubmit"
+      :has-changed.sync="hasFormChanged"
       v-bind="$props"
     >
       <h2><b>Personal data:</b></h2>
@@ -60,6 +65,7 @@ const Template = (args, { argTypes }) => ({
       age: 45,
       address: {},
       submittedDataString: '',
+      hasFormChanged: false,
     };
   },
   methods: {

--- a/src/stories/HdForm.stories.js
+++ b/src/stories/HdForm.stories.js
@@ -30,7 +30,7 @@ const Template = (args, { argTypes }) => ({
   template: `
     <HdForm
       @submit="onSubmit"
-      @hasChanged="onFormChange"
+      @change="onFormChange"
       v-bind="$props"
     >
       <h2><b>Personal data:</b></h2>
@@ -76,7 +76,7 @@ const Template = (args, { argTypes }) => ({
     },
     onFormChange(val) {
       this.hasFormChanged = val;
-      console.log('hasChanged', val);
+      console.log('changed', val);
     },
   },
 });

--- a/tests/unit/components/form/HdForm.spec.js
+++ b/tests/unit/components/form/HdForm.spec.js
@@ -143,9 +143,9 @@ describe('HdForm', () => {
   });
 
   test('a HdForm detects changes if the parent listens to hasChanged event', async () => {
-    const onHasChanged = jest.fn();
+    const onChange = jest.fn();
     const { wrapper, selectors } = hdFormFactory()
-      .withListeners({ hasChanged: onHasChanged })
+      .withListeners({ change: onChange })
       .withSampleForm()
       .build();
 
@@ -153,21 +153,11 @@ describe('HdForm', () => {
 
     await selectors.firstName().setValue('Dave Grohl');
 
-    expect(wrapper.emitted().hasChanged[1][0]).toBe(true);
+    expect(wrapper.emitted().change[1][0]).toBe(true);
 
     await selectors.firstName().setValue(initialFirstNameValue);
 
-    expect(wrapper.emitted().hasChanged[2][0]).toBe(false);
-  });
-
-  test('a HdForm does not emit hasChanged event if there is no listener', async () => {
-    const { wrapper, selectors } = hdFormFactory()
-      .withSampleForm()
-      .build();
-
-    await selectors.firstName().setValue('Dave Grohl');
-
-    expect(wrapper.emitted().hasChanged).toBeFalsy();
+    expect(wrapper.emitted().change[2][0]).toBe(false);
   });
 
   test("a HdForm does not detect changes in child inputs that don't inject 'addFormField'", async () => {

--- a/tests/unit/components/form/HdForm.spec.js
+++ b/tests/unit/components/form/HdForm.spec.js
@@ -153,11 +153,11 @@ describe('HdForm', () => {
 
     await selectors.firstName().setValue('Dave Grohl');
 
-    expect(wrapper.emitted().change[1][0]).toBe(true);
+    expect(wrapper.emitted().change[1][0].hasChanged).toBe(true);
 
     await selectors.firstName().setValue(initialFirstNameValue);
 
-    expect(wrapper.emitted().change[2][0]).toBe(false);
+    expect(wrapper.emitted().change[2][0].hasChanged).toBe(false);
   });
 
   test("a HdForm does not detect changes in child inputs that don't inject 'addFormField'", async () => {

--- a/tests/unit/components/form/HdForm.spec.js
+++ b/tests/unit/components/form/HdForm.spec.js
@@ -140,7 +140,6 @@ describe('HdForm', () => {
 
   test('a HdForm detects changes if the parent needs to access the data through hasChanged prop sync', async () => {
     const { wrapper, selectors } = hdFormFactory()
-      .withProps({ hasChanged: false })
       .withSampleForm()
       .build();
 
@@ -148,21 +147,11 @@ describe('HdForm', () => {
 
     await selectors.firstName().setValue('Dave Grohl');
 
-    expect(wrapper.emitted()['update:hasChanged'][1][0]).toBe(true);
+    expect(wrapper.emitted().hasChanged[1][0]).toBe(true);
 
     await selectors.firstName().setValue(initialFirstNameValue);
 
-    expect(wrapper.emitted()['update:hasChanged'][2][0]).toBe(false);
-  });
-
-  test("a HdForm does not change the hasChanged prop if it's not passed to it", async () => {
-    const { wrapper, selectors } = hdFormFactory()
-      .withSampleForm()
-      .build();
-
-    await selectors.firstName().setValue('Dave Grohl');
-
-    expect(wrapper.emitted()['update:hasChanged']).toBeFalsy();
+    expect(wrapper.emitted().hasChanged[2][0]).toBe(false);
   });
 
   test("a HdForm does not detect changes in child inputs that don't inject 'addFormField'", async () => {

--- a/tests/unit/components/form/HdForm.spec.js
+++ b/tests/unit/components/form/HdForm.spec.js
@@ -123,7 +123,7 @@ describe('HdForm', () => {
     );
   });
 
-  test('a HdForm detects changes in child inputs', async () => {
+  test('a HdForm detects changes in child inputs on submit', async () => {
     const { wrapper, selectors } = hdFormFactory()
       .withSampleForm()
       .build();
@@ -136,6 +136,33 @@ describe('HdForm', () => {
     await selectors.submit().trigger('submit');
 
     expect(wrapper.emitted().submit[1][0].hasChanged).toBe(true);
+  });
+
+  test('a HdForm detects changes if the parent needs to access the data through hasChanged prop sync', async () => {
+    const { wrapper, selectors } = hdFormFactory()
+      .withProps({ hasChanged: false })
+      .withSampleForm()
+      .build();
+
+    const initialFirstNameValue = selectors.firstName().element.value;
+
+    await selectors.firstName().setValue('Dave Grohl');
+
+    expect(wrapper.emitted()['update:hasChanged'][1][0]).toBe(true);
+
+    await selectors.firstName().setValue(initialFirstNameValue);
+
+    expect(wrapper.emitted()['update:hasChanged'][2][0]).toBe(false);
+  });
+
+  test("a HdForm does not change the hasChanged prop if it's not passed to it", async () => {
+    const { wrapper, selectors } = hdFormFactory()
+      .withSampleForm()
+      .build();
+
+    await selectors.firstName().setValue('Dave Grohl');
+
+    expect(wrapper.emitted()['update:hasChanged']).toBeFalsy();
   });
 
   test("a HdForm does not detect changes in child inputs that don't inject 'addFormField'", async () => {

--- a/tests/unit/components/form/HdForm.spec.js
+++ b/tests/unit/components/form/HdForm.spec.js
@@ -21,7 +21,7 @@ describe('HdForm', () => {
     props: {},
     selectors: {},
     build() {
-      this.wrapper = wrapperFactory({ slots: this.slots, props: this.props });
+      this.wrapper = wrapperFactory({ slots: this.slots, props: this.props, listeners: this.listeners });
       return {
         wrapper: this.wrapper,
         selectors: this.selectors,
@@ -29,6 +29,10 @@ describe('HdForm', () => {
     },
     withProps(props = {}) {
       this.props = props;
+      return this;
+    },
+    withListeners(listeners = {}) {
+      this.listeners = listeners;
       return this;
     },
     withDefaultSlot(defaultSlot = {}) {
@@ -138,8 +142,10 @@ describe('HdForm', () => {
     expect(wrapper.emitted().submit[1][0].hasChanged).toBe(true);
   });
 
-  test('a HdForm detects changes if the parent needs to access the data through hasChanged prop sync', async () => {
+  test('a HdForm detects changes if the parent listens to hasChanged event', async () => {
+    const onHasChanged = jest.fn();
     const { wrapper, selectors } = hdFormFactory()
+      .withListeners({ hasChanged: onHasChanged })
       .withSampleForm()
       .build();
 
@@ -152,6 +158,16 @@ describe('HdForm', () => {
     await selectors.firstName().setValue(initialFirstNameValue);
 
     expect(wrapper.emitted().hasChanged[2][0]).toBe(false);
+  });
+
+  test('a HdForm does not emit hasChanged event if there is no listener', async () => {
+    const { wrapper, selectors } = hdFormFactory()
+      .withSampleForm()
+      .build();
+
+    await selectors.firstName().setValue('Dave Grohl');
+
+    expect(wrapper.emitted().hasChanged).toBeFalsy();
   });
 
   test("a HdForm does not detect changes in child inputs that don't inject 'addFormField'", async () => {


### PR DESCRIPTION
I added a new watcher and emitted event to HdForm because we need a way to track if the form has been changed in parent component.

Our specific use case is that we want to confirm with the user if he really wants to leave an unfinished flow via modal, and for that we need to know about the changes. 

