### PR TITLE
[B][FET-243] HdTextarea broken by Grammarly

### DIFF
--- a/src/components/form/HdTextarea.vue
+++ b/src/components/form/HdTextarea.vue
@@ -24,6 +24,7 @@
       :style="{ height }"
       :disabled="disabled"
       class="textarea"
+      data-gramm_editor="false"
       @focus="handleFocus"
       @blur="handleBlur"
       @input="handleInput"

--- a/src/components/form/HdTextarea.vue
+++ b/src/components/form/HdTextarea.vue
@@ -29,6 +29,7 @@
       @blur="handleBlur"
       @input="handleInput"
     />
+    <!-- `data-gramm_editor` attribute is used to control Grammarly (chrome extension) -->
   </TextFieldBase>
 </template>
 

--- a/tests/unit/components/form/__snapshots__/HdTextarea.spec.js.snap
+++ b/tests/unit/components/form/__snapshots__/HdTextarea.spec.js.snap
@@ -4,7 +4,7 @@ exports[`HdTextarea is rendered as expected 1`] = `
 <div class="field text-field">
   <!---->
   <div class="field__body">
-    <div class="field__main"><textarea autocomplete="on" id="test name" name="test name" placeholder="" class="textarea" style="height: 100px;"></textarea> <label for="test name" id="test-name-label" class="field__label">
+    <div class="field__main"><textarea autocomplete="on" id="test name" name="test name" placeholder="" data-gramm_editor="false" class="textarea" style="height: 100px;"></textarea> <label for="test name" id="test-name-label" class="field__label">
         test label
       </label>
       <div class="field__input-right"></div>


### PR DESCRIPTION
https://homeday.atlassian.net/browse/FET-243

Currently, when a user clicks in HdTextarea it shrinks and becomes very small becasue of the injected Grammarly element.

As a fix I added `data-gramm_editor="false"` to disable Grammarly for textarea.

![ezgif-5-9356df35e6a6](https://user-images.githubusercontent.com/7534298/105502819-22ad6100-5cc6-11eb-865e-44a0d6dd9520.gif)
