### PR TITLE
✨ Make the library server-side renderable

### DIFF
--- a/src/services/on-resize.js
+++ b/src/services/on-resize.js
@@ -9,15 +9,21 @@ const debouncedResize = debounce(() => {
   EventEmitter.$emit('resize.debounced');
 }, 300);
 
-window.addEventListener('resize', () => {
-  throttledResize();
-  debouncedResize();
-}, false);
+function addEventListener() {
+  window.addEventListener('resize', () => {
+    throttledResize();
+    debouncedResize();
+  }, false);
 
-window.addEventListener('orientationchange', () => {
-  throttledResize();
-  debouncedResize();
-}, false);
+  window.addEventListener('orientationchange', () => {
+    throttledResize();
+    debouncedResize();
+  }, false);
+}
+
+if (typeof window === 'object') {
+  addEventListener();
+}
 
 export default {
   onThrottled: (cb) => {


### PR DESCRIPTION
### What is this PR about?

This PR makes sure that the `window` object is defined before calling its methods.
The `window` object is only defined on the client side.

That's the only blocking case I've found so far, we might discover some other component-specific cases later and we have to tackle them separately.

### Why?

We want to use homeday-blocks in a Nuxt project.