### PR TITLE
👷  Fix the release workflow and restructure the others

### DIFF
--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -1,0 +1,53 @@
+# This workflow announces the new release on the Frontend Slack channel
+name: Announce the release on Slack
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Announce on Slack 📢
+        run: |
+          curl \
+            -X POST \
+            -H 'Content-type: application/json' \
+            --data \
+            '{
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "'"$TITLE"'"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "'"$NOTES"'",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "plain_text",
+                      "text": "Homeday Blocks"
+                    }
+                  ]
+                }
+              ]
+            }' \
+            $SLACK_RELEASE_BOT_WEBHOOK_URL
+        env:
+          TITLE: "${{ github.event.release.tag_name }} - ${{ github.event.release.name }}"
+          NOTES: "${{ github.event.release.body }}"
+          SLACK_RELEASE_BOT_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_BOT_WEBHOOK_URL }}

--- a/.github/workflows/deploy-pr-to-s3.yml
+++ b/.github/workflows/deploy-pr-to-s3.yml
@@ -1,3 +1,4 @@
+# This workflow takes care of deploying the pull request in an isolated environment for a better QA experience.
 name: Deploy the pull request to AWS S3
 on: [pull_request]
 
@@ -10,26 +11,27 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout 🚪
         uses: actions/checkout@v2
         with:
           persist-credentials: false
 
-      - name: Read .nvmrc
+      - name: Read .nvmrc 🔍
         run: echo "::set-output name=NODE_VERSION::$(cat .nvmrc)"
         id: nvm
 
-      - uses: actions/setup-node@v1
+      - name: Set up the right node version 📌
+        uses: actions/setup-node@v1
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
 
-      - name: Install dependencies
+      - name: Install dependencies ⚙️
         run: npm ci
 
-      - name: Build
+      - name: Build 📦
         run: npm run build:storybook -- -o ./dist/${{ env.REPO_NAME }}/${{ env.PR_NUMBER }}
 
-      - name: Deploy
+      - name: Deploy 🚀
         uses: jakejarvis/s3-sync-action@master
         with:
           args: --acl public-read
@@ -39,7 +41,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           SOURCE_DIR: 'dist'
 
-      - name: Add comment
+      - name: Add comment 💬
         uses: marocchino/sticky-pull-request-comment@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+# This workflow takes care of releasing a new version of the package and publishing it to NPM
+# when a new releasable change (the releasability is detected using the commits Gitmoji) is pushed to master 
 name: Release and publish
 
 on:
@@ -9,65 +11,23 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Read .nvmrc
+      - name: Checkout🚪
+        uses: actions/checkout@v2
+
+      - name: Read .nvmrc 🔍
         run: echo "::set-output name=NODE_VERSION::$(cat .nvmrc)"
         id: nvm
-      - uses: actions/setup-node@v1
+
+      - name: Set up the right node version 📌
+        uses: actions/setup-node@v1
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
-          registry-url: https://registry.npmjs.org/
-      - name: Release and publish
+
+      - name: Install dev dependencies ⚙️
+        run: npm ci --only=dev
+
+      - name: Release and publish 📤
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run semantic-release
-      - uses: octokit/request-action@v2.0.17
-        id: get_latest_release
-        with:
-          route: GET /repos/:repository/releases/latest
-          repository: ${{ github.repository }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Announce on Slack
-        run: |
-          curl \
-            -X POST \
-            -H 'Content-type: application/json' \
-            --data \
-            '{
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "'"$TITLE"'"
-                  }
-                },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "'"$NOTES"'",
-                    "emoji": true
-                  }
-                },
-                {
-                  "type": "context",
-                  "elements": [
-                    {
-                      "type": "plain_text",
-                      "text": "Homeday Blocks"
-                    }
-                  ]
-                }
-              ]
-            }' \
-            $SLACK_RELEASE_BOT_WEBHOOK_URL
-        env:
-          TITLE: "${{fromJson(steps.get_latest_release.outputs.data).tag_name}} - ${{fromJson(steps.get_latest_release.outputs.data).name}}"
-          NOTES: "${{fromJson(steps.get_latest_release.outputs.data).body}}"
-          SLACK_RELEASE_BOT_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_BOT_WEBHOOK_URL }}


### PR DESCRIPTION
There was a problem with the previous implementation, as I wasn't installing the dependencies before running `npm run semantic-release`.

I've also restructured all the workflows (made sure the steps have a descriptive name and added a comment to describe each workflow).

I've adjusted the `announce-on-slack` workflow to use the `release` event payload instead of fetching the latest release manually.