### PR TITLE
🔧 Add Gitmoji prefix to Dependabot's commits

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -7,3 +7,5 @@ update_configs:
     target_branch: "develop"
     default_labels:
       - "bot"
+    commit_message:
+      prefix: "⬆️"


### PR DESCRIPTION
To make it compliant with out workflow.