### PR TITLE
🐛 fix mobile HdDashedList styles

### DIFF
--- a/src/components/HdDashedList.vue
+++ b/src/components/HdDashedList.vue
@@ -83,8 +83,6 @@ $leaders-border: 1px dashed getShade($neutral-gray, 50);
     position: relative;
     display: flex;
     align-items: flex-end;
-    overflow: hidden;
-
   }
 
   > dt {
@@ -105,6 +103,11 @@ $leaders-border: 1px dashed getShade($neutral-gray, 50);
 
 @media (min-width: $break-tablet) {
   .dashed-list__item {
+    > dt,
+    > dd {
+      overflow: hidden;
+    }
+
     > dt {
       position: relative;
       width: 40%;


### PR DESCRIPTION
https://homeday.atlassian.net/browse/REAL-3395

The issue was that the values were not shown for items where there was no primary vaue, but secondary value was present. I adjusted the styles to fix the issue.

### Before:
![Screenshot_20210125-134720_Samsung Internet](https://user-images.githubusercontent.com/3431279/108040493-a9432d00-703d-11eb-8488-db9b497f389f.jpg)

### After:
<img width="417" alt="Screenshot 2021-02-16 at 10 01 10" src="https://user-images.githubusercontent.com/3431279/108040712-f1fae600-703d-11eb-925a-f039809800cd.png">
