### PR TITLE
✨ Pass row context to the table cell slot

### DIFF
--- a/src/components/HdTable.vue
+++ b/src/components/HdTable.vue
@@ -8,7 +8,7 @@
     <tbody>
       <tr v-for="(tr, i) in body" :key="`row-${i}`">
         <td v-for="(value, name) in tr" :key="`cell-${name}`">
-          <slot :name="name" :value="value"><span>{{ value }}</span></slot>
+          <slot :name="name" :value="value" :row-context="tr"><span>{{ value }}</span></slot>
         </td>
       </tr>
     </tbody>

--- a/src/stories/HdTable.stories.js
+++ b/src/stories/HdTable.stories.js
@@ -55,6 +55,10 @@ storiesOf('Components/HdTable', module)
         <template #stars="{value}">
           <HdTagsList :items="value"></HdTagsList>
         </template>
+        <template #year="{value, rowContext}">
+          {{value}}
+          <span v-if="Number(rowContext.rating) >= 9">✨</span> 
+        </template>
       </hd-table>
     `,
     data() {


### PR DESCRIPTION
While implementing the [hd-connect dashboard](https://github.com/homeday-de/hd-connect/tree/REAL-3614/dashboard) had the need to access the context of the columns within the cell slot, so we added it.