### PR TITLE
🐛  HD Modal Mobile Alignment Bugfix

### DIFF
--- a/src/components/HdModal.vue
+++ b/src/components/HdModal.vue
@@ -167,6 +167,7 @@ $mobile-browser-footer-buffer: 75px;
   padding: #{$sp-l + $sp-s} $sp-m $sp-m;
   background-color: $white;
   border-radius: 4px;
+  overflow: hidden;
 }
 
 .hd-modal__header {

--- a/src/components/HdModal.vue
+++ b/src/components/HdModal.vue
@@ -131,6 +131,7 @@ $mobile-browser-footer-buffer: 75px;
 
 .hd-modal {
   position: fixed;
+  z-index: 100;
   display: flex;
   top: 0;
   left: 0;

--- a/src/components/HdModal.vue
+++ b/src/components/HdModal.vue
@@ -127,6 +127,7 @@ export default {
 
 <style lang="scss" scoped>
 @import 'homeday-blocks/src/styles/mixins.scss';
+$mobile-browser-footer-buffer: 75px;
 
 .hd-modal {
   position: fixed;
@@ -137,7 +138,7 @@ export default {
   height: 100vh;
   align-items: flex-end;
   justify-content: center;
-  padding: #{$sp-m + $sp-s} $sp-m;
+  padding: #{$sp-m + $sp-s} $sp-m #{$sp-m + $mobile-browser-footer-buffer} $sp-m;
 
   @media (min-width: $break-tablet) {
     align-items: center;


### PR DESCRIPTION
## WHAT
The bottom of the modal wasn't showing properly on mobile devices because of the browser's menu. We added a buffer to the padding of the modal to change the position a bit.

## BUG
![2](https://user-images.githubusercontent.com/14016028/118979712-0de19100-b979-11eb-90ac-8ba6d00087be.jpeg)

## FIX
![1](https://user-images.githubusercontent.com/14016028/118979733-13d77200-b979-11eb-956d-226929d3548e.jpeg)
