### PR TITLE
👷 use slack-release-bot-action

### DIFF
--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -14,7 +14,8 @@ jobs:
         uses: LoveToKnow/slackify-markdown-action@v1.0.0
         with:
           text: ${{ github.event.release.body }}
-      - uses: homeday-de/slack-release-bot-action@0.0.1
+      - name: Announce on Slack 📢 
+        uses: homeday-de/slack-release-bot-action@0.0.1
         with:
           webhook_url: ${{ secrets.SLACK_RELEASE_BOT_WEBHOOK_URL }}
           title: ${{ github.event.release.name }}

--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -14,34 +14,9 @@ jobs:
         uses: LoveToKnow/slackify-markdown-action@v1.0.0
         with:
           text: ${{ github.event.release.body }}
-      - name: Announce on Slack 📢
-        run: |
-          curl \
-            -X POST \
-            -H 'Content-type: application/json' \
-            --data \
-            '{
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "'"$NOTES"'"
-                  }
-                },
-                {
-                  "type": "context",
-                  "elements": [
-                    {
-                      "type": "plain_text",
-                      "text": "Homeday Blocks"
-                    }
-                  ]
-                }
-              ]
-            }' \
-            $SLACK_RELEASE_BOT_WEBHOOK_URL
-        env:
-          TITLE: ${{ github.event.release.name }}
-          NOTES: ${{ steps.release_body.outputs.text }}
-          SLACK_RELEASE_BOT_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_BOT_WEBHOOK_URL }}
+      - uses: homeday-de/slack-release-bot-action@0.0.1
+        with:
+          webhook_url: ${{ secrets.SLACK_RELEASE_BOT_WEBHOOK_URL }}
+          title: ${{ github.event.release.name }}
+          body: ${{ steps.release_body.outputs.text }}
+          context: Homeday Blocks


### PR DESCRIPTION
It uses the recently created GitHub Action to post releases on Slack: https://github.com/homeday-de/slack-release-bot-action

We have this `curl` in two places already (Sliders and Blocks) and it might be used by other projects so instead of having copy-paste everywhere we can have a single source of truth.

There is one difference: the action uses a `divider` between title and body.