### PR TITLE
✨ Add closing event on HdModal Overlay

### DIFF
--- a/src/components/HdModal.vue
+++ b/src/components/HdModal.vue
@@ -5,7 +5,7 @@
       class="hd-modal"
       :class="{ 'hd-modal--with-icon': withIcon }"
     >
-      <div class="hd-modal__overlay" @click="onCloseClick" />
+      <div class="hd-modal__overlay" @click="onClose" />
       <slot>
         <div class="hd-modal__container">
           <header class="hd-modal__header">
@@ -50,7 +50,7 @@
           <button
             v-if="isCloseButtonVisible"
             class="hd-modal__close-button"
-            @click="onCloseClick()"
+            @click="onClose()"
           >
             <hd-icon
               :src="closeIcon"
@@ -120,7 +120,7 @@ export default {
     },
   },
   methods: {
-    onCloseClick() {
+    onClose() {
       this.$emit('close');
     },
   },

--- a/src/components/HdModal.vue
+++ b/src/components/HdModal.vue
@@ -5,7 +5,7 @@
       class="hd-modal"
       :class="{ 'hd-modal--with-icon': withIcon }"
     >
-      <div class="hd-modal__overlay" />
+      <div class="hd-modal__overlay" @click="onCloseClick" />
       <slot>
         <div class="hd-modal__container">
           <header class="hd-modal__header">
@@ -50,7 +50,7 @@
           <button
             v-if="isCloseButtonVisible"
             class="hd-modal__close-button"
-            @click="$emit('close')"
+            @click="onCloseClick()"
           >
             <hd-icon
               :src="closeIcon"

--- a/tests/unit/components/HdModal.spec.js
+++ b/tests/unit/components/HdModal.spec.js
@@ -5,6 +5,7 @@ const TITLE_SELECTOR = '.hd-modal__title';
 const BODY_SELECTOR = '.hd-modal__body';
 const ACTIONS_SELECTOR = '.hd-modal__footer';
 const CLOSE_BUTTON_SELECTOR = '.hd-modal__close-button';
+const OVERLAY_SELECTOR = '.hd-modal__overlay';
 const HEADER_SELECTOR = '.hd-modal__header';
 const ICON_SELECTOR = 'hd-icon-stub';
 const WITH_ICON_SELECTOR = '.hd-modal--with-icon';
@@ -120,5 +121,13 @@ describe('HdModal', () => {
     const wrapper = wrapperWithOverridingDefaultSlotBuilder();
 
     expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders the modal and trigger a click on the overlay', async () => {
+    const wrapper = wrapperBuilder();
+
+    await wrapper.find(OVERLAY_SELECTOR).trigger('click');
+
+    expect(wrapper.emitted().close).toBeTruthy();
   });
 });


### PR DESCRIPTION
### Modal should be closed when a user clicks on the overlay.
----

This is the outcome of the last [Design system sync](https://homeday.atlassian.net/wiki/spaces/PE/pages/2209218870/2021-07-21+Design+System+Inactive+icons+focus+toast). so clicking on overlay should close the HdModal.

> Our modal definitely needs to be updated so that it automatically closes when the user clicks anywhere outside of it.