### PR TITLE
✨ Add keysToCamelCase & keysToSnakeCase helper function into UtilsService

### DIFF
--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -171,6 +171,7 @@ export function cloneVNodeElement (vnode, { props, attrs, children, ...rest }, h
   }, cloned.componentOptions.children || children)
 }
 
+// Deeply converts the keys of a given object to camelCase
 export function keysToCamelCase(collection) {
   if (_isPlainObject(collection)) {
     const newCollection = {};
@@ -190,6 +191,7 @@ export function keysToCamelCase(collection) {
   return collection;
 }
 
+// Deeply converts the keys of a given object to snake_case
 export function keysToSnakeCase(collection) {
   if (_isPlainObject(collection)) {
     const newCollection = {};

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import merge from 'lodash/merge';
+import _merge from 'lodash/merge';
 import _isArray from 'lodash/isArray';
 import _isPlainObject from 'lodash/isPlainObject';
 import _camelCase from 'lodash/camelCase';
@@ -23,10 +23,10 @@ export function formatNestedData(data, nestingString = '.') {
         acc[currentKey] = value;
         return acc;
       }
-      acc = merge({}, { [currentKey]: acc });
+      acc = _merge({}, { [currentKey]: acc });
       return acc;
     }, {});
-    merge(formattedObj, nestedSubObj);
+    _merge(formattedObj, nestedSubObj);
   });
   return formattedObj;
 }

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -1,5 +1,9 @@
 /* eslint-disable */
 import merge from 'lodash/merge';
+import _isArray from 'lodash/isArray';
+import _isPlainObject from 'lodash/isPlainObject';
+import _camelCase from 'lodash/camelCase';
+import _snakeCase from 'lodash/snakeCase';
 
 /** Replace all the occurrences in a string */
 export function populateTemplate(template, map) {
@@ -167,6 +171,44 @@ export function cloneVNodeElement (vnode, { props, attrs, children, ...rest }, h
   }, cloned.componentOptions.children || children)
 }
 
+export function keysToCamelCase(collection) {
+  if (_isPlainObject(collection)) {
+    const newCollection = {};
+
+    Object.keys(collection)
+      .forEach((item) => {
+        newCollection[_camelCase(item)] = keysToCamelCase(collection[item]);
+      });
+
+    return newCollection;
+  }
+
+  if (_isArray(collection)) {
+    return collection.map((item) => keysToCamelCase(item));
+  }
+
+  return collection;
+}
+
+export function keysToSnakeCase(collection) {
+  if (_isPlainObject(collection)) {
+    const newCollection = {};
+
+    Object.keys(collection)
+      .forEach((item) => {
+        newCollection[_snakeCase(item)] = keysToSnakeCase(collection[item]);
+      });
+
+    return newCollection;
+  }
+
+  if (_isArray(collection)) {
+    return collection.map((item) => keysToSnakeCase(item));
+  }
+
+  return collection;
+}
+
 export default {
   populateTemplate,
   getPasswordStrength,
@@ -176,4 +218,6 @@ export default {
   getArrayOfSize,
   loadScript,
   generateUniqueNumbers,
+  keysToCamelCase,
+  keysToSnakeCase,
 };

--- a/tests/unit/services/utils.spec.js
+++ b/tests/unit/services/utils.spec.js
@@ -3,7 +3,7 @@ import {
   loadScript,
   cloneVNodeElement,
   keysToCamelCase,
-  keysToSnakeCase
+  keysToSnakeCase,
 } from '@/services/utils';
 import { mount } from '@vue/test-utils';
 

--- a/tests/unit/services/utils.spec.js
+++ b/tests/unit/services/utils.spec.js
@@ -1,5 +1,81 @@
-import { generateUniqueNumbers, loadScript, cloneVNodeElement } from '@/services/utils';
+import {
+  generateUniqueNumbers,
+  loadScript,
+  cloneVNodeElement,
+  keysToCamelCase,
+  keysToSnakeCase
+} from '@/services/utils';
 import { mount } from '@vue/test-utils';
+
+const SNAKE_CASE_DATA = {
+  category_to_test_out: {
+    my_uri: '/categories/0b092e7c-4d2c-4eba-8c4e-80937c9e483d',
+    parent_name: 'Food',
+    name_of_product: {
+      name_of: { name_of_of: 'John' },
+      age_of: [{ array_object: 'John' }, 40, 50],
+      car_type: null,
+    },
+    super_deep_object: {
+      a_ridiculously_deep_object: {
+        now_you_are_pulling_my_leg: 'well yes, just a little bit',
+        seriously_gone_too_far_this_time: {
+          what_do_you_have_to_say_for_yourself: 'ok i\'ll back off a touch',
+        },
+      },
+      must_rid_me_of_this_snake_case: 'okie dokie - whatever you ask',
+      please_let_me_up_for_air: 'ok mister, away you go',
+    },
+  },
+  amount_owing_array: [
+    { jon_smith: 50, patti_smith: 30 },
+    20,
+    20,
+    {
+      my_dad: [
+        { oh_my_lordy: 'deep array object bro', yes_sir: 'really deep' },
+        40,
+        { yo_ho: 'very very very deep' },
+      ],
+    },
+  ],
+  debit_run: true,
+};
+
+const CAMEL_CASE_DATA = {
+  categoryToTestOut: {
+    myUri: '/categories/0b092e7c-4d2c-4eba-8c4e-80937c9e483d',
+    parentName: 'Food',
+    nameOfProduct: {
+      nameOf: { nameOfOf: 'John' },
+      ageOf: [{ arrayObject: 'John' }, 40, 50],
+      carType: null,
+    },
+    superDeepObject: {
+      aRidiculouslyDeepObject: {
+        nowYouArePullingMyLeg: 'well yes, just a little bit',
+        seriouslyGoneTooFarThisTime: {
+          whatDoYouHaveToSayForYourself: "ok i'll back off a touch",
+        },
+      },
+      mustRidMeOfThisSnakeCase: 'okie dokie - whatever you ask',
+      pleaseLetMeUpForAir: 'ok mister, away you go',
+    },
+  },
+  amountOwingArray: [
+    { jonSmith: 50, pattiSmith: 30 },
+    20,
+    20,
+    {
+      myDad: [
+        { ohMyLordy: 'deep array object bro', yesSir: 'really deep' },
+        40,
+        { yoHo: 'very very very deep' },
+      ],
+    },
+  ],
+  debitRun: true,
+};
 
 describe('Utils service', () => {
   describe('generateRandomNumbers', () => {
@@ -94,6 +170,18 @@ describe('Utils service', () => {
 
       expect(wrapper.text()).toContain('Alexander');
       expect(wrapper.text()).toContain('comrade');
+    });
+  });
+
+  describe('keysToCamelCase', () => {
+    it('deeply converts the keys of a given object to camelCase', () => {
+      expect(keysToCamelCase(SNAKE_CASE_DATA)).toEqual(CAMEL_CASE_DATA);
+    });
+  });
+
+  describe('keysToSnakeCase', () => {
+    it('deeply converts the keys of a given object to snake_case', () => {
+      expect(keysToSnakeCase(CAMEL_CASE_DATA)).toEqual(SNAKE_CASE_DATA);
     });
   });
 });


### PR DESCRIPTION
https://homeday.atlassian.net/browse/VIEW-291

We are using `keysToCamelCase` & `keysToSnakeCase` helper functions in customer-app and Sliders. 
As @viniciuskneves 's [suggestion](https://github.com/homeday-de/sliders/pull/1700#pullrequestreview-714678698)
It makes sense to move them to Blocks and have a single source of truth.

Reference from customer-app: 
- [src/services/utils.js#L105-L141](https://github.com/homeday-de/customer-app/blob/develop/src/services/utils.js#L105-L141)
- [tests/unit/services/utils.spec.js#L323-L333](https://github.com/homeday-de/customer-app/blob/develop/tests/unit/services/utils.spec.js#L323-L333)

Will create a tech debt ticket to migrate those current functions to use the helper functions from Blocks in customer-app. 
Of course, after we upgrade homeday-blocks to the newest version in customer-app :) 
