### PR TITLE
🔧  Use the library as an ES module and define the side effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "prepare": "husky install"
   },
   "main": "main.js",
+  "module": "main.js",
+  "sideEffects": false,
   "files": [
     "src/*",
     "*.json",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "main": "main.js",
   "module": "main.js",
-  "sideEffects": false,
+  "sideEffects": ["*.vue"],
   "files": [
     "src/*",
     "*.json",


### PR DESCRIPTION
Webpack is doing a bad job at tree-shaking our library. If you check the builds of your projects you'll see that all the components are included, even the ones that are not being used.

So we have to help Webpack a bit, first by providing a `module` entry, because we are using ES modules, and defining any side effects.

I kept `main` as well, because it's needed when running tests as this is how `@vue/babel-preset-app` is configured, see: [modules](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/babel-preset-app#modules).

I've set the `sideEffects` to `"*.vue"` so we can also include the the styles of the component (it doesn't include all the styles, just the ones that the component depend on).
_That took me quite some time to figue out, even gave me side effects personally 😆   I was trying with `"*.css"`, but actually the css is just the output, and I should have used `.vue` because that's what Webpack "reads"._

### Results:
Here are the results from a very small project which uses only one component from Blocks (HdInput).
#### Before
![Screen Shot 2021-07-30 at 11 55 31 AM](https://user-images.githubusercontent.com/30146019/127671189-4a8466e5-d7d8-4191-8909-555b08d301b7.png)
#### After
![Screen Shot 2021-07-30 at 4 40 27 PM](https://user-images.githubusercontent.com/30146019/127671187-d4f2e1a1-6a8a-4995-9fac-203a709e6dc1.png)

That's a huge difference! 😃 

You can install and try this branch on your projects by running:
```
npm i homeday-de/homeday-blocks#lib-as-module --save
```
To make sure that nothing breaks on your projects and to see how many KBs you've saved :D

For optimal results please upgrade your version of `homeday-assets` as well.