### PR TITLE
🐛 Add main.scss file to package.json sideEffects prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "main": "main.js",
   "module": "main.js",
-  "sideEffects": ["*.vue"],
+  "sideEffects": ["*.vue", "src/styles/main.scss"],
   "files": [
     "src/*",
     "*.json",

--- a/src/stories/Welcome.vue
+++ b/src/stories/Welcome.vue
@@ -3,7 +3,7 @@
     <h1 class="welcome__title">Homeday-Blocks</h1>
     <p class="welcome__paragraph">A Vue component library built by Homeday's frontend team.</p>
 
-    <h3 class="welcome__subtitle">Start using the library in 2 quick steps</h3>
+    <h3 class="welcome__subtitle">Start using the library in 3 quick steps</h3>
     <p class="welcome__paragraph">
       1- Install the library:
       <vue-code-highlight class="welcome__code">{{
@@ -12,6 +12,10 @@
       2- Consume the components
       <vue-code-highlight class="welcome__code">{{
         "import { HdGallery } from 'homeday-blocks';"
+      }}</vue-code-highlight>
+      3- Import global css file
+      <vue-code-highlight class="welcome__code">{{
+        "import 'homeday-blocks/src/styles/main.scss';"
       }}</vue-code-highlight>
     </p>
 


### PR DESCRIPTION
After the [previous release](https://github.com/homeday-de/homeday-blocks/pull/794) we had a problem with global styling inside Storybooks:

![image](https://user-images.githubusercontent.com/1855125/128051161-9d2f0c99-42d3-4533-b5f6-885b358295ba.png)

To fix that, we added this property to include `main.scss` file into blocks context.

## Notes

- This is not actually a good thing since every component should contain its own styles and not depend on global/external styles, and we should at some point in time refactor that
- For now, we added this "quick fix" to always include the global styling in blocks, but the tree shaking will continue to work in other applications
- We also added one extra instruction step inside our "Welcome" story to warn the user that they must include the global styling