### PR TITLE
💄 Scope HdButton styles

### DIFF
--- a/src/components/buttons/HdButton.vue
+++ b/src/components/buttons/HdButton.vue
@@ -105,12 +105,10 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @import 'homeday-blocks/src/styles/_variables.scss';
 
 .btn {
-  $root: &;
-
   &--icon-button {
     padding: $sp-s;
   }
@@ -120,13 +118,13 @@ export default {
     height: 24px;
     margin-right: $sp-xs;
 
-    #{$root}--icon-button & {
+    .btn--icon-button & {
       width: 28px;
       height: 28px;
       margin-right: 0;
     }
 
-    path {
+    ::v-deep path {
       fill: currentColor;
     }
   }


### PR DESCRIPTION
Added `scoped` attribute to HdButton styles to fix the issue of "icon button" styles being overridden with the button styles defined in `/src/styles/buttons.scss` (loaded with `main.scss`). 
Having styles scoped increases specificity for icon buttons and fixes the layout to be as expected.

Before:
<img width="986" alt="Screenshot 2021-08-05 at 15 15 26" src="https://user-images.githubusercontent.com/3431279/128358263-82319750-156f-4375-969d-93be96ac44eb.png">
