### PR TITLE
:lipstick: remove fixed width of HdGalleryCarousel image

### DIFF
--- a/src/components/gallery/HdGalleryCarousel.vue
+++ b/src/components/gallery/HdGalleryCarousel.vue
@@ -294,7 +294,6 @@ export default {
       z-index: 1;
 
     img {
-      width: 100%;
       height: 100%;
       object-fit: cover;
     }


### PR DESCRIPTION
[Ticket: REAL-4009](https://homeday.atlassian.net/secure/RapidBoard.jspa?rapidView=7&modal=detail&selectedIssue=REAL-4009)

**Before:** 

![before](https://user-images.githubusercontent.com/88391711/130628589-107d1c34-cc74-449e-974c-ed63773878ac.PNG)

**After removing `width:100%` from `HdGalleryCarousel image`:** 

![after](https://user-images.githubusercontent.com/88391711/130628726-980ac8bd-8cf2-45db-b24a-5efcd0b6571c.PNG)



