### PR TITLE
💡 Suggestion about the carousel component

### DIFF
--- a/src/components/gallery/HdGalleryCarousel.vue
+++ b/src/components/gallery/HdGalleryCarousel.vue
@@ -14,26 +14,28 @@
         ref="flickity"
         :options="flickityOptions"
       >
-        <div
-          class="gallery-carousel__item"
-          v-for="(item, i) in items"
-          :key="i"
-          :class="{
-            'is-active': shouldShowActiveState(i),
-          } "
-        >
-          <div :style="sizerStyles" />
+        <slot>
+          <div
+            class="gallery-carousel__item"
+            v-for="(item, i) in items"
+            :key="i"
+            :class="{
+              'is-active': shouldShowActiveState(i),
+            } "
+          >
+            <div :style="sizerStyles" />
 
-          <!-- the item.thumbnail field is used as default value for the item image -->
-          <!-- IE11 uses this value only because do not support the picture element -->
-          <picture class="gallery-carousel__picture">
-            <source v-for="(source, media) in item.thumbnailPictureSources"
-                    :key="media"
-                    :media="`(${media})`" :srcset="source"
-            >
-            <img :src="item.thumbnail" :alt="item.caption" :srcset="item.thumbnailSrcSet" :style="{objectFit}">
-          </picture>
-        </div>
+            <!-- the item.thumbnail field is used as default value for the item image -->
+            <!-- IE11 uses this value only because do not support the picture element -->
+            <picture class="gallery-carousel__picture">
+              <source v-for="(source, media) in item.thumbnailPictureSources"
+                      :key="media"
+                      :media="`(${media})`" :srcset="source"
+              >
+              <img :src="item.thumbnail" :alt="item.caption" :srcset="item.thumbnailSrcSet" :style="{objectFit}">
+            </picture>
+          </div>
+        </slot>
       </flickity>
       <div class="gallery-carousel__pager">
         <HdPager

--- a/src/stories/HdGalleryCarousel.stories.js
+++ b/src/stories/HdGalleryCarousel.stories.js
@@ -1,0 +1,80 @@
+import { HdGalleryCarousel } from 'homeday-blocks';
+import { pictures as picturesIcon } from 'homeday-assets/L';
+import ITEMS from './mocks/GALLERY_ITEMS';
+
+export default {
+  title: 'Components/Gallery/HdGalleryCarousel',
+  component: HdGalleryCarousel,
+  argTypes: {
+    items: {
+      type: 'object',
+    },
+    carouselItemClick: {
+      action: 'carouselItemClicked',
+    },
+    currentItemClick: {
+      action: 'currentItemClicked',
+    },
+    input: {
+      action: 'input',
+    },
+  },
+  args: {
+    items: ITEMS,
+    pagerInside: false,
+    disableKeyEvents: false,
+    showCaption: true,
+    startIndex: 0,
+    carouselObjectFit: 'cover',
+    placeholderText: 'Nothing to show',
+    placeholderIcon: picturesIcon,
+  },
+};
+
+const Template = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { HdGalleryCarousel },
+  template: `
+    <div style="max-width: 800px; padding-left: 16px; padding-right: 16px; margin: auto;">
+    <HdGalleryCarousel
+      :items="items"
+      :pager-inside="pagerInside"
+      :aspect-ratio="aspectRatio"
+      :disable-key-events="disableKeyEvents"
+      :start-index="startIndex"
+      :show-caption="showCaption"
+      :placeholder-icon="placeholderIcon"
+      :placeholder-text="placeholderText"
+      :carousel-object-fit="carouselObjectFit"
+      @carouselItemClick="carouselItemClick"
+      @currentItemClick="currentItemClick"
+      @input="input"
+    />
+    </div>
+  `,
+});
+
+export const Default = Template.bind({});
+
+export const Slot = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { HdGalleryCarousel },
+  template: `
+    <div style="max-width: 800px; padding-left: 16px; padding-right: 16px; margin: auto;">
+    <HdGalleryCarousel
+      :pager-inside="pagerInside"
+      :aspect-ratio="aspectRatio"
+      :disable-key-events="disableKeyEvents"
+      :start-index="startIndex"
+      :show-caption="showCaption"
+      :placeholder-icon="placeholderIcon"
+      :placeholder-text="placeholderText"
+      :carousel-object-fit="carouselObjectFit"
+      @carouselItemClick="carouselItemClick"
+      @currentItemClick="currentItemClick"
+      @input="input">
+      <div style="width: 100%;" v-for="(item, index) in items">This is item #{{ index }}</div>
+    </HdGalleryCarousel>
+    </div>
+  `,
+});


### PR DESCRIPTION
Hey @homeday-de/frontend-engineering, I don't have any intention to merge this (yet) but to raise a question and see everyone's thoughts.
About the HdGalleryCarousel component.

**Current state**
It's a hidden component (we don't have stories for it - so no documentation) that we have in homeday-blocks and allows us to create a carousel for images. Like the gif below.
![Components _ Gallery _ HdGalleryCarousel - Default ⋅ Storybook](https://user-images.githubusercontent.com/2879127/132341738-300e2c00-7c0a-4568-8db7-020a64fc5659.gif)

Right now it is being used on the HdGallery, also located in homeday-blocks. So we need to make sure this continue working as it is right now.

**Suggestion**
Why don't we make it more reusable? On the website migration we have the need for a component like this:
![image](https://user-images.githubusercontent.com/2879127/132341964-94054513-9fd5-43e3-b10d-1989aab6e344.png)

One way to achieve it is to have a slot where we currently have the .gallery-carousel__item, rename the component to HdCarousel and then on the new HdGalleryCarousel we can just fill in the slot with the .gallery-carousel__item (as it was before). So the current component would continue working as it is right now and open the possibility to add something else in the carousel besides just images.

The code below contemplates just part of the suggested changes, but it's enough to get a preview:
![Components _ Gallery _ HdGalleryCarousel - Slot ⋅ Storybook](https://user-images.githubusercontent.com/2879127/132342497-6ffe432a-cd0c-4cd9-abe4-15d84b14885a.gif)

This would enable the articles component on our website coming from this component, and we would still have the old component working.

What do you think? Let me know.