### PR TITLE
🐛  Make HDTextarea component scrollable, without messing with the label

### DIFF
--- a/src/components/form/FieldBase.vue
+++ b/src/components/form/FieldBase.vue
@@ -179,6 +179,7 @@ export default {
   }
   &__label {
     position: absolute;
+    z-index: 2;
     top: $sp-m;
     left: $sp-m;
     transform-origin: left;

--- a/src/components/form/HdTextarea.vue
+++ b/src/components/form/HdTextarea.vue
@@ -12,7 +12,8 @@
     @clear-click="clearTextarea"
     @status-click="focusTextarea"
     :class="{
-      'field--maxlength-indicator-visible': isMaxlengthIndicatorVisible
+      'field--maxlength-indicator-visible': isMaxlengthIndicatorVisible,
+      'field--label-background-visible': shouldShowLabelBackground,
     }"
   >
     <textarea
@@ -32,10 +33,6 @@
       @focus="handleFocus"
       @blur="handleBlur"
       @input="handleInput"
-    />
-    <div
-      v-if="label && (isActive || value)"
-      class="textarea__label-background"
     />
     <span
       v-if="isMaxlengthIndicatorVisible"
@@ -136,6 +133,9 @@ export default {
     isMaxlengthIndicatorVisible() {
       return this.maxlength < Number.POSITIVE_INFINITY;
     },
+    shouldShowLabelBackground() {
+      return this.label && (this.isActive || this.value);
+    },
     placeholderAttr() {
       if (!this.placeholder) {
         return '';
@@ -198,15 +198,6 @@ export default {
 @import 'homeday-blocks/src/styles/mixins.scss';
 $distanceFromTextareaToIndicator: -18px;
 
-.textarea__label-background {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: $sp-l - $sp-s; // Same as the padding top from the textarea, defined on FieldBase
-  background-color: $secondary-bg;
-}
-
 .textarea {
   display: block;
   resize: vertical;
@@ -226,4 +217,20 @@ $distanceFromTextareaToIndicator: -18px;
     }
   }
 }
+
+.field--label-background-visible {
+  ::v-deep {
+    .field__main::after {
+      content: '';
+      position: absolute;
+      z-index: 1;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: $sp-l - $sp-s; // Same as the padding top from the textarea, defined on FieldBase
+      background-color: $secondary-bg;
+    }
+  }
+}
+
 </style>

--- a/tests/unit/components/form/__snapshots__/HdTextarea.spec.js.snap
+++ b/tests/unit/components/form/__snapshots__/HdTextarea.spec.js.snap
@@ -5,7 +5,6 @@ exports[`HdTextarea is rendered as expected 1`] = `
   <!---->
   <div class="field__body">
     <div class="field__main"><textarea autocomplete="on" id="test name" name="test name" placeholder="" maxlength="Infinity" data-gramm_editor="false" class="textarea" style="height: 100px;"></textarea>
-      <!---->
       <!----> <label for="test name" id="test-name-label" class="field__label">
         test label
       </label>


### PR DESCRIPTION
This PR fixes these 2 problems: 
https://homeday.atlassian.net/browse/DS-195
https://homeday.atlassian.net/browse/DS-194

The HDTextarea component is scrollable again by excluding the `textarea` selector to be affected by the `overflow: hidden` style.

Also, the label is not being affected by the scrolled text because I added a background on the HDTextarea component, and is only visible when the `textarea` has text or is focused.
My first approach to solve this last one was adding a background to the label tag on the FieldBase component, but when I did that I needed to deal with the measures because the label is being affected by a `transform: scale(0.7)`. I thought it would be easier to add the "floating div" behind the label to the textarea component, as it is the only component affected by the scroll behavior.

Let me know your thoughts! 🙏🏼 
