### PR TITLE
🐛  Avoid overglow of HdToggle icon

### DIFF
--- a/src/components/HdToggle.vue
+++ b/src/components/HdToggle.vue
@@ -212,7 +212,7 @@ $_controlIconSize: 32px;
     text-align: left;
     transition: outline $time-s ease-in-out;
 
-    // avoids to expand out of the content due to animation
+    // avoids to expand out of the container due to svg sizing
     overflow: hidden;
 
     @media (min-width: $break-tablet) {

--- a/src/components/HdToggle.vue
+++ b/src/components/HdToggle.vue
@@ -212,6 +212,9 @@ $_controlIconSize: 32px;
     text-align: left;
     transition: outline $time-s ease-in-out;
 
+    // avoids to expand out of the content due to animation
+    overflow: hidden;
+
     @media (min-width: $break-tablet) {
       @include font('title');
     }


### PR DESCRIPTION
As you can see, the chevron icon can overflow because of sizing. This avoids effecting the outher layout.

![image](https://user-images.githubusercontent.com/19528860/140788394-aac4f246-dbb9-4ced-b6b1-1cc747963781.png)
