### PR TITLE
♿️ Add type button for Calendar, Modal, Toast and ArrowButton components

### DIFF
--- a/src/components/HdCalendar.vue
+++ b/src/components/HdCalendar.vue
@@ -2,6 +2,7 @@
   <div class="calendar">
     <header class="calendar__header">
       <button
+        type="button"
         class="calendar__button calendar__header__button calendar__button--prev"
         :class="{'calendar__button--disabled': selectedWeekIndexTail - cycleLengthWeeks < 0}"
         @click="setWeekIndexTail(-cycleLengthWeeks)"
@@ -19,6 +20,7 @@
         </template>
       </span>
       <button
+        type="button"
         class="calendar__button calendar__header__button calendar__button--next"
         :class="{'calendar__button--disabled': selectedWeekIndexTail + cycleLengthWeeks >= availableWeeks.length}"
         @click="setWeekIndexTail(cycleLengthWeeks)"

--- a/src/components/HdModal.vue
+++ b/src/components/HdModal.vue
@@ -49,6 +49,7 @@
 
           <button
             v-if="isCloseButtonVisible"
+            type="button"
             class="hd-modal__close-button"
             @click="onClose()"
           >

--- a/src/components/HdToast.vue
+++ b/src/components/HdToast.vue
@@ -6,12 +6,14 @@
   <section v-if="hasLabels" class="toast__controls">
     <button
       v-if="secondaryLabel"
+      type="button"
       class="toast__control toast__control--secondary"
       @click="secondaryClick"
       v-text="secondaryLabel"
     />
     <button
       v-if="primaryLabel"
+      type="button"
       class="toast__control toast__control--primary"
       @click="primaryClick"
       v-text="primaryLabel"

--- a/src/components/buttons/HdArrowButton.vue
+++ b/src/components/buttons/HdArrowButton.vue
@@ -6,6 +6,7 @@
     }"
     autocomplete="off"
     :disabled="disabled"
+    type="button"
   >
     <HdIcon
       :src="chevronIcon"

--- a/tests/unit/components/__snapshots__/HdCalendar.spec.js.snap
+++ b/tests/unit/components/__snapshots__/HdCalendar.spec.js.snap
@@ -2,11 +2,11 @@
 
 exports[`HdCalendar renders component 1`] = `
 <div class="calendar">
-  <header class="calendar__header"><button class="calendar__button calendar__header__button calendar__button--prev calendar__button--disabled">
+  <header class="calendar__header"><button type="button" class="calendar__button calendar__header__button calendar__button--prev calendar__button--disabled">
       <hdicon-stub src="" transform="rotate(180)" width="100%" height="100%"></hdicon-stub>
     </button> <span class="calendar__header__month">
         Mai
-      </span> <button class="calendar__button calendar__header__button calendar__button--next">
+      </span> <button type="button" class="calendar__button calendar__header__button calendar__button--next">
       <hdicon-stub src="" width="100%" height="100%"></hdicon-stub>
     </button></header>
   <section class="calendar__body">

--- a/tests/unit/components/__snapshots__/HdModal.spec.js.snap
+++ b/tests/unit/components/__snapshots__/HdModal.spec.js.snap
@@ -14,7 +14,7 @@ exports[`HdModal renders component 1`] = `
       <div class="hd-modal__body">
         <div>This is the modal body.</div>
       </div>
-      <footer class=""></footer> <button class="hd-modal__close-button">
+      <footer class=""></footer> <button type="button" class="hd-modal__close-button">
         <hd-icon-stub src="" class="hd-modal__close-icon"></hd-icon-stub>
       </button>
     </div>

--- a/tests/unit/components/__snapshots__/HdToast.spec.js.snap
+++ b/tests/unit/components/__snapshots__/HdToast.spec.js.snap
@@ -4,7 +4,7 @@ exports[`HdToast 'primaryLabel' text binds to primary <button> 1`] = `
 <div class="toast">
   <p class="toast__text"></p>
   <section class="toast__controls">
-    <!----> <button class="toast__control toast__control--primary">random-text</button>
+    <!----> <button type="button" class="toast__control toast__control--primary">random-text</button>
   </section>
 </div>
 `;
@@ -12,7 +12,7 @@ exports[`HdToast 'primaryLabel' text binds to primary <button> 1`] = `
 exports[`HdToast 'secondaryLabel' text binds to secondary <button> 1`] = `
 <div class="toast">
   <p class="toast__text"></p>
-  <section class="toast__controls"><button class="toast__control toast__control--secondary">random-text</button>
+  <section class="toast__controls"><button type="button" class="toast__control toast__control--secondary">random-text</button>
     <!---->
   </section>
 </div>

--- a/tests/unit/components/buttons/__snapshots__/HdArrowButton.spec.js.snap
+++ b/tests/unit/components/buttons/__snapshots__/HdArrowButton.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HdArrowButton renders component 1`] = `
-<button autocomplete="off" class="arrowButton arrowButton--right">
+<button autocomplete="off" type="button" class="arrowButton arrowButton--right">
   <!---->
 </button>
 `;


### PR DESCRIPTION
Buttons should have an explicit `type` attribute defined, otherwise, if we add this component inside of a form, the button will automatically behave like a submit button.

This PR is to fix a problem with our current task: 
> we are rendering the `HdCalendar` inside of a form, but when we click on the "arrow button" inside of the calendar, it is triggering a form submission.

We took advantage and also added a `type="button"` for other general components.