### PR TITLE
👷  Semantic releases: Fix the way we compare gitmojis

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -38,6 +38,10 @@ module.exports = {
                 .forEach((commit) => {
                   const gitmoji = gitmojis.find(({ emoji }) => emoji.localeCompare(commit.gitmoji) === 0);
 
+                  if (gitmoji === undefined) {
+                    return;
+                  }
+
                   groupedCommits = {
                     ...groupedCommits,
                     [gitmoji.semver]: [

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -36,7 +36,7 @@ module.exports = {
               allCommits
                 .filter((commit) => commit !== undefined)
                 .forEach((commit) => {
-                  const gitmoji = gitmojis.find(({ emoji }) => emoji === commit.gitmoji);
+                  const gitmoji = gitmojis.find(({ emoji }) => emoji.localeCompare(commit.gitmoji) === 0);
 
                   groupedCommits = {
                     ...groupedCommits,


### PR DESCRIPTION
## Short description
This PR includes a fix to properly compare the Gitmojis to avoid [this issue](https://github.com/homeday-de/homeday-blocks/runs/4190894388?check_suite_focus=true).

## Longer version
The PR from @kuroski surfaced a little issue we have with the automated releases.
The issue was because when the script was trying to compare the two strings with `===` and that didn't work, you can test it yourself:
```js
'♿️' === '♿'; // false
```
If you debug deeper you'll see that the first string has a length of `2` instead of one, and the reason is having a hidden character ([(VARIATION SELECTOR-16)](https://www.fileformat.info/info/unicode/char/fe0f/index.htm) which is used to select a variant of an emoji, like gender or skin color). We can also use `String.charCodeAt(0)` to compare just the first character of the string (which is the emoji in our case), but I preferred `String.localeCompare` to also handle the case of emoji variants (if Gitmoji starts using them in the future).

This PR also handle the case of using an emoji that is not a valid Gitmoji, which we should of course avoid, but it's not good to break the release just because of uncompliant emoji.