### PR TITLE
🐛 Fix flag-icons-svg styles import paths in HdInputPhone

### DIFF
--- a/src/components/form/HdInputPhone.vue
+++ b/src/components/form/HdInputPhone.vue
@@ -299,9 +299,9 @@ export default {
 <style lang="scss" scoped>
 @import 'homeday-blocks/src/styles/mixins.scss';
 
-$flag-icons-path: '../../../node_modules/flag-icons-svg/svg';
-@import './node_modules/flag-icons-svg/sass/_variables.scss';
-@import './node_modules/flag-icons-svg/sass/flag-icons.scss';
+$flag-icons-path: '~flag-icons-svg/svg';
+@import '~flag-icons-svg/sass/_variables.scss';
+@import '~flag-icons-svg/sass/flag-icons.scss';
 
 $dropdown-button-width: 74px;
 $dropdown-button-height: 55px;


### PR DESCRIPTION
In this PR [HdInputPhone ](https://github.com/homeday-de/homeday-blocks/blob/master/src/components/form/HdInputPhone.vue)component `flag-icons-svg` styles were fixed because they were being imported with relative paths that can't be resolved when using homeday-blocks in other projects.