### PR TITLE
:bug: [VIEW-659] Fix form field style when browser extensions manipulate DOM

### DIFF
--- a/src/components/form/FieldBase.vue
+++ b/src/components/form/FieldBase.vue
@@ -149,15 +149,6 @@ export default {
   &:not(#{$root}--grouped) &__main {
     position: relative;
 
-    & > :first-child {
-      width: 100%;
-      background: $secondary-bg;
-      border-radius: 4px 4px 0 0;
-      &:not(textarea) {
-        overflow: hidden;
-      }
-    }
-
     input, textarea, select {
       padding-top: $sp-l - $sp-s;
       padding-right: $sp-s;
@@ -176,7 +167,19 @@ export default {
         color: getShade($quaternary-color, 60);
       }
     }
+
+    & > {
+      .split-input,
+      input[type]:not([type="checkbox"]):not([type="radio"]),
+      textarea,
+      select {
+        width: 100%;
+        background: $secondary-bg;
+        border-radius: 4px 4px 0 0;
+      }
+    }
   }
+
   &__label {
     position: absolute;
     z-index: 2;

--- a/src/components/form/HdSplitInput.vue
+++ b/src/components/form/HdSplitInput.vue
@@ -171,6 +171,7 @@ export default {
 
 .split-input {
   display: flex;
+  overflow: hidden;
 
   &__input {
     width: 100%;

--- a/src/components/form/HdTextarea.vue
+++ b/src/components/form/HdTextarea.vue
@@ -29,7 +29,6 @@
       :disabled="disabled"
       :maxlength="maxlength"
       class="textarea"
-      data-gramm_editor="false"
       @focus="handleFocus"
       @blur="handleBlur"
       @input="handleInput"

--- a/tests/unit/components/form/__snapshots__/HdTextarea.spec.js.snap
+++ b/tests/unit/components/form/__snapshots__/HdTextarea.spec.js.snap
@@ -4,7 +4,7 @@ exports[`HdTextarea is rendered as expected 1`] = `
 <div class="field text-field">
   <!---->
   <div class="field__body">
-    <div class="field__main"><textarea autocomplete="on" id="test name" name="test name" placeholder="" maxlength="Infinity" data-gramm_editor="false" class="textarea" style="height: 100px;"></textarea>
+    <div class="field__main"><textarea autocomplete="on" id="test name" name="test name" placeholder="" maxlength="Infinity" class="textarea" style="height: 100px;"></textarea>
       <!----> <label for="test name" id="test-name-label" class="field__label">
         test label
       </label>


### PR DESCRIPTION
### What changes does this PR introduce.
- Ensure form element styles stay the same when browser extensions manipulate the DOM by replacing `> :first-child` with `> selector`

### A brief reasoning behind the change.
- Input styles could be influenced by a code change or extensions DOM manipulation.
 
### Any instructions on how to test the changes.
A form elements smoke test; components those this change would effect are:
- HdSelect
- HdSplitInfo
- TextFieldBase > HdGoogleAutocomplete
- TextFieldBase > HdTextarea
- TextFieldBase > HdInput 
- TextFieldBase > HdInput > HdDynamicForm
- TextFieldBase > HdInput > HdInputPassword
- TextFieldBase > HdInput > HdInputFormatter
- TextFieldBase > HdInputFormatter > HdInputPhone

_The Jira ticket:_ [VIEW-659](https://homeday.atlassian.net/browseVIEW-659)