### PR TITLE
:bug: Bind HdSplitInput story icon to knobs

### DIFF
--- a/src/stories/HdSplitInput.stories.js
+++ b/src/stories/HdSplitInput.stories.js
@@ -81,7 +81,7 @@ storiesOf('Components/Form/HdSplitInput', module)
       <HdSplitInput
         v-model="value"
         :fields="fields"
-        icon="fake/icon.svg"
+        :icon="icon"
         name="test"
         label="Label"
       />


### PR DESCRIPTION
This PR would fix the issue: storybooks HdSplitInput icon wouldn't show up and you couldn't change it either.

![image](https://user-images.githubusercontent.com/3007713/159445927-44416689-d91d-4945-b15b-74a6cce34654.png)
