### PR TITLE
:arrow_up: Bump home-assets from 4.41.0 to 4.43.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18028,9 +18028,9 @@
       }
     },
     "homeday-assets": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/homeday-assets/-/homeday-assets-4.41.0.tgz",
-      "integrity": "sha512-aF61G09mlxw60gaxNUwm2xce7zMJeLq1oMN0Q3sJ5jcQEsRnyRJ2WLGd97H1s635oyCw3j/98zdvb3ryC/xz8A=="
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/homeday-assets/-/homeday-assets-4.43.0.tgz",
+      "integrity": "sha512-V88XbarEyoDaSV65ZPD260iCaC0m5GuUBvxgQksndE/ipnrwEB5yMdaD0+ASk6RyOq30Dyny9K0zgnvW0ARdUw=="
     },
     "hook-std": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "country-codes-list": "^1.6.8",
     "deepmerge": "^4.2.2",
     "flag-icons-svg": "0.0.3",
-    "homeday-assets": "^4.41.0",
+    "homeday-assets": "^4.43.0",
     "lodash": "4.17.21",
     "natural-scroll": "0.2.2",
     "vue": "2.6.14",


### PR DESCRIPTION
Upgrade to the latest homeday assets and trigger Storybook build

Fix arrow-back overwriting arrow flagged by @ivandata on Slack https://homeday.slack.com/archives/CMQ63UMD0/p1648479929348739 