### PR TITLE
♻️ Include both JS & TS component types and services in the build script input files

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -32,8 +32,10 @@ const blackListedFiles = [
   cleanUpOutputDirectory();
 
   const components = findFilesByExtension(componentsPath, 'vue');
-  const componentTypes = findFilesByExtension(componentsPath, 'ts');
-  const services = findFilesByExtension(servicesPath, 'js');
+  const componentTypes = findFilesByExtension(componentsPath, 'js')
+    .concat(findFilesByExtension(componentsPath, 'ts'));
+  const services = findFilesByExtension(servicesPath, 'js')
+    .concat(findFilesByExtension(servicesPath, 'ts'));;
   const filesToBeCompiled = omitBlackListedFiles(components.concat(componentTypes, services));
 
   const buildResult = await build(filesToBeCompiled);


### PR DESCRIPTION
Include both JS & TS component types and services in the build script input files because `src/components/tooltip/HdTooltipInstaller.js` wasn't built even though it is needed in customer-app