### PR TITLE
:bug: Remove button style's scoped attr, since this breaks products tests

### DIFF
--- a/src/components/buttons/HdButton.vue
+++ b/src/components/buttons/HdButton.vue
@@ -98,11 +98,13 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
 @import 'homeday-blocks/src/styles/_variables.scss';
 
 .btn {
-  &--icon-button {
+  $root: &;
+
+  &#{$root}--icon-button {
     padding: $sp-s;
   }
 
@@ -111,13 +113,13 @@ export default {
     height: 24px;
     margin-right: $sp-xs;
 
-    .btn--icon-button & {
+    #{$root}--icon-button & {
       width: 28px;
       height: 28px;
       margin-right: 0;
     }
 
-    ::v-deep path {
+    path {
       fill: currentColor;
     }
   }

--- a/src/styles/buttons.scss
+++ b/src/styles/buttons.scss
@@ -72,6 +72,13 @@ $button-transition: all $time-s ease-in-out;
     border: 2px solid transparent;
     transition: border-color .3s ease-in-out;
   }
+
+  &::before,
+  &::after,
+  &__icon,
+  &__content {
+    pointer-events: none;
+  }
 }
 
 .btn--primary {


### PR DESCRIPTION
## Why
Removing unnecessary button style's scoped attr that breaks customer-app tests, scoped was originally add to prioritize the button icon padding override. 
 
## Related PR
https://github.com/homeday-de/homeday-blocks/pull/797