### PR TITLE
⬆️ Upgrade semantic-release & semantic-release-gitmoji dependecies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3704,23 +3704,23 @@
       }
     },
     "@octokit/auth-token": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
-      "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
       "dev": true,
       "requires": {
         "@octokit/types": "^6.0.3"
       }
     },
     "@octokit/core": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz",
-      "integrity": "sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+      "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
       "dev": true,
       "requires": {
         "@octokit/auth-token": "^2.4.4",
         "@octokit/graphql": "^4.5.8",
-        "@octokit/request": "^5.6.0",
+        "@octokit/request": "^5.6.3",
         "@octokit/request-error": "^2.0.5",
         "@octokit/types": "^6.0.3",
         "before-after-hook": "^2.2.0",
@@ -3747,9 +3747,9 @@
       }
     },
     "@octokit/graphql": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.4.tgz",
-      "integrity": "sha512-SWTdXsVheRmlotWNjKzPOb6Js6tjSqA2a8z9+glDJng0Aqjzti8MEWOtuT8ZSu6wHnci7LZNuarE87+WJBG4vg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
       "dev": true,
       "requires": {
         "@octokit/request": "^5.6.0",
@@ -3758,18 +3758,18 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-8.3.0.tgz",
-      "integrity": "sha512-ZFyQ30tNpoATI7o+Z9MWFUzUgWisB8yduhcky7S4UYsRijgIGSnwUKzPBDGzf/Xkx1DuvUtqzvmuFlDSqPJqmQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
+      "integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA==",
       "dev": true
     },
     "@octokit/plugin-paginate-rest": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.14.0.tgz",
-      "integrity": "sha512-S2uEu2uHeI7Vf+Lvj8tv3O5/5TCAa8GHS0dUQN7gdM7vKA6ZHAbR6HkAVm5yMb1mbedLEbxOuQ+Fa0SQ7tCDLA==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz",
+      "integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^6.18.0"
+        "@octokit/types": "^6.34.0"
       }
     },
     "@octokit/plugin-request-log": {
@@ -3779,26 +3779,26 @@
       "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.4.1.tgz",
-      "integrity": "sha512-Nx0g7I5ayAYghsLJP4Q1Ch2W9jYYM0FlWWWZocUro8rNxVwuZXGfFd7Rcqi9XDWepSXjg1WByiNJnZza2hIOvQ==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz",
+      "integrity": "sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^6.18.1",
+        "@octokit/types": "^6.34.0",
         "deprecation": "^2.3.1"
       }
     },
     "@octokit/request": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.0.tgz",
-      "integrity": "sha512-4cPp/N+NqmaGQwbh3vUsYqokQIzt7VjsgTYVXiwpUP2pxd5YiZB2XuTedbb0SPtv9XS7nzAKjAuQxmY8/aZkiA==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.1.0",
         "@octokit/types": "^6.16.1",
         "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.1",
+        "node-fetch": "^2.6.7",
         "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
@@ -3807,6 +3807,37 @@
           "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
           "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
           "dev": true
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+          "dev": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "dev": true,
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
         }
       }
     },
@@ -3822,24 +3853,24 @@
       }
     },
     "@octokit/rest": {
-      "version": "18.6.7",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.6.7.tgz",
-      "integrity": "sha512-Kn6WrI2ZvmAztdx+HEaf88RuJn+LK72S8g6OpciE4kbZddAN84fu4fiPGxcEu052WmqKVnA/cnQsbNlrYC6rqQ==",
+      "version": "18.12.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
+      "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
       "dev": true,
       "requires": {
-        "@octokit/core": "^3.5.0",
-        "@octokit/plugin-paginate-rest": "^2.6.2",
-        "@octokit/plugin-request-log": "^1.0.2",
-        "@octokit/plugin-rest-endpoint-methods": "5.4.1"
+        "@octokit/core": "^3.5.1",
+        "@octokit/plugin-paginate-rest": "^2.16.8",
+        "@octokit/plugin-request-log": "^1.0.4",
+        "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
       }
     },
     "@octokit/types": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.19.0.tgz",
-      "integrity": "sha512-9wdZFiJfonDyU6DjIgDHxAIn92vdSUBOwAXbO2F9rOFt6DJwuAkyGLu1CvdJPphCbPBoV9iSDMX7y4fu0v6AtA==",
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
+      "integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
       "dev": true,
       "requires": {
-        "@octokit/openapi-types": "^8.3.0"
+        "@octokit/openapi-types": "^11.2.0"
       }
     },
     "@percy/react-percy-api-client": {
@@ -3919,41 +3950,38 @@
       }
     },
     "@semantic-release/commit-analyzer": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-8.0.1.tgz",
-      "integrity": "sha512-5bJma/oB7B4MtwUkZC2Bf7O1MHfi4gWe4mA+MIQ3lsEV0b422Bvl1z5HRpplDnMLHH3EXMoRdEng6Ds5wUqA3A==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-9.0.2.tgz",
+      "integrity": "sha512-E+dr6L+xIHZkX4zNMe6Rnwg4YQrWNXK+rNsvwOPpdFppvZO1olE2fIgWhv89TkQErygevbjsZFSIxp+u6w2e5g==",
       "dev": true,
       "requires": {
         "conventional-changelog-angular": "^5.0.0",
         "conventional-commits-filter": "^2.0.0",
-        "conventional-commits-parser": "^3.0.7",
+        "conventional-commits-parser": "^3.2.3",
         "debug": "^4.0.0",
-        "import-from": "^3.0.0",
+        "import-from": "^4.0.0",
         "lodash": "^4.17.4",
         "micromatch": "^4.0.2"
       },
       "dependencies": {
         "import-from": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
-          "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
-          "dev": true,
-          "requires": {
-            "resolve-from": "^5.0.0"
-          }
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+          "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
+          "dev": true
         }
       }
     },
     "@semantic-release/error": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
-      "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+      "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
       "dev": true
     },
     "@semantic-release/github": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-7.2.3.tgz",
-      "integrity": "sha512-lWjIVDLal+EQBzy697ayUNN8MoBpp+jYIyW2luOdqn5XBH4d9bQGfTnjuLyzARZBHejqh932HVjiH/j4+R7VHw==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.4.tgz",
+      "integrity": "sha512-But4e8oqqP3anZI5tjzZssZc2J6eoUdeeE0s7LVKKwyiAXJiQDWNNvtPOpgG2DsIz4+Exuse7cEQgjGMxwtLmg==",
       "dev": true,
       "requires": {
         "@octokit/rest": "^18.0.0",
@@ -3964,16 +3992,28 @@
         "dir-glob": "^3.0.0",
         "fs-extra": "^10.0.0",
         "globby": "^11.0.0",
-        "http-proxy-agent": "^4.0.0",
+        "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "issue-parser": "^6.0.0",
         "lodash": "^4.17.4",
-        "mime": "^2.4.3",
+        "mime": "^3.0.0",
         "p-filter": "^2.0.0",
         "p-retry": "^4.0.0",
         "url-join": "^4.0.0"
       },
       "dependencies": {
+        "@semantic-release/error": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
+          "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
+          "dev": true
+        },
+        "@tootallnate/once": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+          "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+          "dev": true
+        },
         "agent-base": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -3984,14 +4024,25 @@
           }
         },
         "fs-extra": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+          "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
+          }
+        },
+        "http-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+          "dev": true,
+          "requires": {
+            "@tootallnate/once": "2",
+            "agent-base": "6",
+            "debug": "4"
           }
         },
         "https-proxy-agent": {
@@ -4014,6 +4065,12 @@
             "universalify": "^2.0.0"
           }
         },
+        "mime": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+          "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+          "dev": true
+        },
         "p-retry": {
           "version": "4.6.1",
           "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
@@ -4033,19 +4090,19 @@
       }
     },
     "@semantic-release/npm": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-7.1.3.tgz",
-      "integrity": "sha512-x52kQ/jR09WjuWdaTEHgQCvZYMOTx68WnS+TZ4fya5ZAJw4oRtJETtrvUw10FdfM28d/keInQdc66R1Gw5+OEQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.1.tgz",
+      "integrity": "sha512-I5nVZklxBzfMFwemhRNbSrkiN/dsH3c7K9+KSk6jUnq0rdLFUuJt7EBsysq4Ir3moajQgFkfEryEHPqiKJj20g==",
       "dev": true,
       "requires": {
-        "@semantic-release/error": "^2.2.0",
+        "@semantic-release/error": "^3.0.0",
         "aggregate-error": "^3.0.0",
         "execa": "^5.0.0",
         "fs-extra": "^10.0.0",
         "lodash": "^4.17.15",
         "nerf-dart": "^1.0.0",
         "normalize-url": "^6.0.0",
-        "npm": "^7.0.0",
+        "npm": "^8.3.0",
         "rc": "^1.2.8",
         "read-pkg": "^5.0.0",
         "registry-auth-token": "^4.0.0",
@@ -4082,9 +4139,9 @@
           }
         },
         "fs-extra": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+          "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
@@ -4105,9 +4162,9 @@
           "dev": true
         },
         "is-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
           "dev": true
         },
         "jsonfile": {
@@ -4119,6 +4176,12 @@
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
           }
+        },
+        "lru-cache": {
+          "version": "7.8.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
+          "integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg==",
+          "dev": true
         },
         "mimic-fn": {
           "version": "2.1.0",
@@ -4181,12 +4244,12 @@
           }
         },
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "version": "7.3.6",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+          "integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
           "dev": true,
           "requires": {
-            "lru-cache": "^6.0.0"
+            "lru-cache": "^7.4.0"
           }
         },
         "shebang-command": {
@@ -4222,18 +4285,18 @@
       }
     },
     "@semantic-release/release-notes-generator": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-9.0.3.tgz",
-      "integrity": "sha512-hMZyddr0u99OvM2SxVOIelHzly+PP3sYtJ8XOLHdMp8mrluN5/lpeTnIO27oeCYdupY/ndoGfvrqDjHqkSyhVg==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-10.0.3.tgz",
+      "integrity": "sha512-k4x4VhIKneOWoBGHkx0qZogNjCldLPRiAjnIpMnlUh6PtaWXp/T+C9U7/TaNDDtgDa5HMbHl4WlREdxHio6/3w==",
       "dev": true,
       "requires": {
         "conventional-changelog-angular": "^5.0.0",
-        "conventional-changelog-writer": "^4.0.0",
+        "conventional-changelog-writer": "^5.0.0",
         "conventional-commits-filter": "^2.0.0",
-        "conventional-commits-parser": "^3.0.0",
+        "conventional-commits-parser": "^3.2.3",
         "debug": "^4.0.0",
         "get-stream": "^6.0.0",
-        "import-from": "^3.0.0",
+        "import-from": "^4.0.0",
         "into-stream": "^6.0.0",
         "lodash": "^4.17.4",
         "read-pkg-up": "^7.0.0"
@@ -4256,13 +4319,10 @@
           "dev": true
         },
         "import-from": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
-          "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
-          "dev": true,
-          "requires": {
-            "resolve-from": "^5.0.0"
-          }
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+          "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
+          "dev": true
         },
         "parse-json": {
           "version": "5.2.0",
@@ -11615,23 +11675,6 @@
       "integrity": "sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q==",
       "dev": true
     },
-    "cli-table": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.6.tgz",
-      "integrity": "sha512-ZkNZbnZjKERTY5NwC2SeMeLeifSPq/pubeRoTpdr3WchLlnZg6hEgvHkK5zL7KNFdd9PmHN8lxrENUwI3cE8vQ==",
-      "dev": true,
-      "requires": {
-        "colors": "1.0.3"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-          "dev": true
-        }
-      }
-    },
     "cli-table3": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
@@ -12160,9 +12203,9 @@
       "dev": true
     },
     "conventional-changelog-angular": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.12.tgz",
-      "integrity": "sha512-5GLsbnkR/7A89RyHLvvoExbiGbd9xKdKqDTrArnPbOqBqG/2wIosu0fHwpeIRI8Tl94MhVNBXcLJZl92ZQ5USw==",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
+      "integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0",
@@ -12170,15 +12213,14 @@
       }
     },
     "conventional-changelog-writer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.1.0.tgz",
-      "integrity": "sha512-WwKcUp7WyXYGQmkLsX4QmU42AZ1lqlvRW9mqoyiQzdD+rJWbTepdWoKJuwXTS+yq79XKnQNa93/roViPQrAQgw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.1.tgz",
+      "integrity": "sha512-5WsuKUfxW7suLblAbFnxAcrvf6r+0b7GvNaWUwUIk0bXMnENP/PEieGKVUQrjPqwPT4o3EPAASBXiY6iHooLOQ==",
       "dev": true,
       "requires": {
-        "compare-func": "^2.0.0",
         "conventional-commits-filter": "^2.0.7",
         "dateformat": "^3.0.0",
-        "handlebars": "^4.7.6",
+        "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.15",
         "meow": "^8.0.0",
@@ -12204,9 +12246,9 @@
           }
         },
         "hosted-git-info": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
-          "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+          "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -12232,24 +12274,30 @@
           }
         },
         "normalize-package-data": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
-          "integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+          "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
           "dev": true,
           "requires": {
             "hosted-git-info": "^4.0.1",
-            "resolve": "^1.20.0",
+            "is-core-module": "^2.5.0",
             "semver": "^7.3.4",
             "validate-npm-package-license": "^3.0.1"
           },
           "dependencies": {
+            "lru-cache": {
+              "version": "7.8.1",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
+              "integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg==",
+              "dev": true
+            },
             "semver": {
-              "version": "7.3.5",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-              "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+              "version": "7.3.6",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+              "integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
               "dev": true,
               "requires": {
-                "lru-cache": "^6.0.0"
+                "lru-cache": "^7.4.0"
               }
             }
           }
@@ -12380,9 +12428,9 @@
       }
     },
     "conventional-commits-parser": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.1.tgz",
-      "integrity": "sha512-OG9kQtmMZBJD/32NEw5IhN5+HnBqVjy03eC+I71I0oQRFA5rOgA4OtPOYG7mz1GkCfCNxn3gKIX8EiHJYuf1cA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz",
+      "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.0.4",
@@ -12390,8 +12438,7 @@
         "lodash": "^4.17.15",
         "meow": "^8.0.0",
         "split2": "^3.0.0",
-        "through2": "^4.0.0",
-        "trim-off-newlines": "^1.0.0"
+        "through2": "^4.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -12405,9 +12452,9 @@
           }
         },
         "hosted-git-info": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
-          "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+          "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -12433,13 +12480,13 @@
           }
         },
         "normalize-package-data": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
-          "integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+          "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
           "dev": true,
           "requires": {
             "hosted-git-info": "^4.0.1",
-            "resolve": "^1.20.0",
+            "is-core-module": "^2.5.0",
             "semver": "^7.3.4",
             "validate-npm-package-license": "^3.0.1"
           }
@@ -12537,12 +12584,20 @@
           }
         },
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "version": "7.3.6",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+          "integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
           "dev": true,
           "requires": {
-            "lru-cache": "^6.0.0"
+            "lru-cache": "^7.4.0"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "7.8.1",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
+              "integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg==",
+              "dev": true
+            }
           }
         },
         "through2": {
@@ -14571,12 +14626,13 @@
       "dev": true
     },
     "env-ci": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.0.2.tgz",
-      "integrity": "sha512-Xc41mKvjouTXD3Oy9AqySz1IeyvJvHZ20Twf5ZLYbNpPPIuCnL/qHCmNlD01LoNy0JTunw9HPYVptD19Ac7Mbw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.5.0.tgz",
+      "integrity": "sha512-o0JdWIbOLP+WJKIUt36hz1ImQQFuN92nhsfTkHHap+J8CiI8WgGpH/a9jEGHh4/TU5BUUGjlnKXNoDb57+ne+A==",
       "dev": true,
       "requires": {
-        "execa": "^4.0.0",
+        "execa": "^5.0.0",
+        "fromentries": "^1.3.2",
         "java-properties": "^1.0.0"
       },
       "dependencies": {
@@ -14592,35 +14648,38 @@
           }
         },
         "execa": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+          "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
           "dev": true,
           "requires": {
-            "cross-spawn": "^7.0.0",
-            "get-stream": "^5.0.0",
-            "human-signals": "^1.1.1",
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.0",
+            "human-signals": "^2.1.0",
             "is-stream": "^2.0.0",
             "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.0",
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2",
+            "npm-run-path": "^4.0.1",
+            "onetime": "^5.1.2",
+            "signal-exit": "^3.0.3",
             "strip-final-newline": "^2.0.0"
           }
         },
         "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+          "dev": true
+        },
+        "human-signals": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+          "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+          "dev": true
         },
         "is-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
           "dev": true
         },
         "mimic-fn": {
@@ -16610,6 +16669,7 @@
       "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz",
       "integrity": "sha512-SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
         "@types/json-schema": "^7.0.5",
@@ -16629,6 +16689,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -16638,6 +16699,7 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -16648,6 +16710,7 @@
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -16656,25 +16719,29 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "7.8.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.0.tgz",
           "integrity": "sha512-AmXqneQZL3KZMIgBpaPTeI6pfwh+xQ2vutMsyqOu1TBdEXFZgpG/80wuJ531w2ZN7TI0/oc8CPxzh/DKQudZqg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "schema-utils": {
           "version": "2.7.0",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
           "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@types/json-schema": "^7.0.4",
             "ajv": "^6.12.2",
@@ -16686,6 +16753,7 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
           "integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
           "dev": true,
+          "optional": true,
           "requires": {
             "lru-cache": "^7.4.0"
           }
@@ -16695,6 +16763,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -16748,6 +16817,12 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
       }
+    },
+    "fromentries": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+      "dev": true
     },
     "front-matter": {
       "version": "4.0.2",
@@ -17098,9 +17173,9 @@
       }
     },
     "git-url-parse": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.5.0.tgz",
-      "integrity": "sha512-TZYSMDeM37r71Lqg1mbnMlOqlHd7BSij9qN7XwTkRqSAYFMihGLGhfHwgqQob3GUhEneKnV4nskN9rbQw2KGxA==",
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.6.0.tgz",
+      "integrity": "sha512-WWUxvJs5HsyHL6L08wOusa/IXYtMuCAhrMmnTjQPpBU0TTHyDhnOATNH3xNQz7YOQUsqIIPTGr4xiVti1Hsk5g==",
       "dev": true,
       "requires": {
         "git-up": "^4.0.0"
@@ -23434,12 +23509,6 @@
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
-    "lodash.toarray": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
-      "dev": true
-    },
     "lodash.transform": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.transform/-/lodash.transform-4.6.0.tgz",
@@ -23643,73 +23712,93 @@
       "dev": true
     },
     "marked": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
-      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.14.tgz",
+      "integrity": "sha512-HL5sSPE/LP6U9qKgngIIPTthuxC0jrfxpYMZ3LdGDD3vTnLs59m2Z7r6+LNDR3ToqEQdkKd6YaaEfJhodJmijQ==",
       "dev": true
     },
     "marked-terminal": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-4.1.1.tgz",
-      "integrity": "sha512-t7Mdf6T3PvOEyN01c3tYxDzhyKZ8xnkp8Rs6Fohno63L/0pFTJ5Qtwto2AQVuDtbQiWzD+4E5AAu1Z2iLc8miQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-5.1.1.tgz",
+      "integrity": "sha512-+cKTOx9P4l7HwINYhzbrBSyzgxO2HaHKGZGuB1orZsMIgXYaJyfidT81VXRdpelW/PcHEWxywscePVgI/oUF6g==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^4.3.1",
+        "ansi-escapes": "^5.0.0",
         "cardinal": "^2.1.1",
-        "chalk": "^4.1.0",
-        "cli-table": "^0.3.1",
-        "node-emoji": "^1.10.0",
-        "supports-hyperlinks": "^2.1.0"
+        "chalk": "^5.0.0",
+        "cli-table3": "^0.6.1",
+        "node-emoji": "^1.11.0",
+        "supports-hyperlinks": "^2.2.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+        "ansi-escapes": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
+          "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
           "dev": true,
           "requires": {
-            "color-convert": "^2.0.1"
+            "type-fest": "^1.0.2"
           }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+          "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
           "dev": true
         },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+        "cli-table3": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+          "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
           "dev": true,
           "requires": {
-            "has-flag": "^4.0.0"
+            "colors": "1.4.0",
+            "string-width": "^4.2.0"
           }
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "type-fest": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+          "dev": true
         }
       }
     },
@@ -24470,12 +24559,12 @@
       }
     },
     "node-emoji": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
-      "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
+      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "requires": {
-        "lodash.toarray": "^4.4.0"
+        "lodash": "^4.17.21"
       }
     },
     "node-fetch": {
@@ -24840,108 +24929,125 @@
       "dev": true
     },
     "npm": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-7.20.0.tgz",
-      "integrity": "sha512-59Eje4RcXP9EKYPIJvBvQGTyfEvZWaKdOx5+YZ+IJ+fqYhJJH5ng78qcdD8sFPyA1g1MFBR0DYXKfncwbxXpVA==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-8.6.0.tgz",
+      "integrity": "sha512-icekvN8FJFESIFkLaFEVl05Nocl5Id5HnoVhJzhCUvtNY8tj9kfUlH/J527fZq/8ltsAUqpettfutwRjQYS2fA==",
       "dev": true,
       "requires": {
-        "@npmcli/arborist": "^2.7.1",
-        "@npmcli/ci-detect": "^1.2.0",
-        "@npmcli/config": "^2.2.0",
+        "@isaacs/string-locale-compare": "^1.1.0",
+        "@npmcli/arborist": "^5.0.4",
+        "@npmcli/ci-detect": "^2.0.0",
+        "@npmcli/config": "^4.0.1",
+        "@npmcli/fs": "^2.1.0",
+        "@npmcli/map-workspaces": "^2.0.2",
         "@npmcli/package-json": "^1.0.1",
-        "@npmcli/run-script": "^1.8.5",
+        "@npmcli/run-script": "^3.0.1",
         "abbrev": "~1.1.1",
         "ansicolors": "~0.3.2",
         "ansistyles": "~0.1.3",
         "archy": "~1.0.0",
-        "byte-size": "^7.0.1",
-        "cacache": "^15.2.0",
-        "chalk": "^4.1.0",
+        "cacache": "^16.0.3",
+        "chalk": "^4.1.2",
         "chownr": "^2.0.0",
-        "cli-columns": "^3.1.2",
-        "cli-table3": "^0.6.0",
-        "columnify": "~1.5.4",
-        "glob": "^7.1.7",
-        "graceful-fs": "^4.2.6",
-        "hosted-git-info": "^4.0.2",
+        "cli-columns": "^4.0.0",
+        "cli-table3": "^0.6.1",
+        "columnify": "^1.6.0",
+        "fastest-levenshtein": "^1.0.12",
+        "glob": "^7.2.0",
+        "graceful-fs": "^4.2.9",
+        "hosted-git-info": "^5.0.0",
         "ini": "^2.0.0",
-        "init-package-json": "^2.0.3",
+        "init-package-json": "^3.0.2",
         "is-cidr": "^4.0.2",
         "json-parse-even-better-errors": "^2.3.1",
-        "leven": "^3.1.0",
-        "libnpmaccess": "^4.0.2",
-        "libnpmdiff": "^2.0.4",
-        "libnpmexec": "^2.0.0",
-        "libnpmfund": "^1.1.0",
-        "libnpmhook": "^6.0.2",
-        "libnpmorg": "^2.0.2",
-        "libnpmpack": "^2.0.1",
-        "libnpmpublish": "^4.0.1",
-        "libnpmsearch": "^3.1.1",
-        "libnpmteam": "^2.0.3",
-        "libnpmversion": "^1.2.1",
-        "make-fetch-happen": "^9.0.4",
-        "minipass": "^3.1.3",
+        "libnpmaccess": "^6.0.2",
+        "libnpmdiff": "^4.0.2",
+        "libnpmexec": "^4.0.2",
+        "libnpmfund": "^3.0.1",
+        "libnpmhook": "^8.0.2",
+        "libnpmorg": "^4.0.2",
+        "libnpmpack": "^4.0.2",
+        "libnpmpublish": "^6.0.2",
+        "libnpmsearch": "^5.0.2",
+        "libnpmteam": "^4.0.2",
+        "libnpmversion": "^3.0.1",
+        "make-fetch-happen": "^10.1.1",
+        "minipass": "^3.1.6",
         "minipass-pipeline": "^1.2.4",
         "mkdirp": "^1.0.4",
         "mkdirp-infer-owner": "^2.0.0",
         "ms": "^2.1.2",
-        "node-gyp": "^7.1.2",
+        "node-gyp": "^9.0.0",
         "nopt": "^5.0.0",
-        "npm-audit-report": "^2.1.5",
-        "npm-package-arg": "^8.1.5",
-        "npm-pick-manifest": "^6.1.1",
-        "npm-profile": "^5.0.3",
-        "npm-registry-fetch": "^11.0.0",
+        "npm-audit-report": "^3.0.0",
+        "npm-install-checks": "^4.0.0",
+        "npm-package-arg": "^9.0.1",
+        "npm-pick-manifest": "^7.0.0",
+        "npm-profile": "^6.0.2",
+        "npm-registry-fetch": "^13.1.0",
         "npm-user-validate": "^1.0.1",
-        "npmlog": "~4.1.2",
+        "npmlog": "^6.0.1",
         "opener": "^1.5.2",
-        "pacote": "^11.3.5",
-        "parse-conflict-json": "^1.1.1",
+        "pacote": "^13.0.5",
+        "parse-conflict-json": "^2.0.2",
+        "proc-log": "^2.0.1",
         "qrcode-terminal": "^0.12.0",
         "read": "~1.0.7",
-        "read-package-json": "^3.0.1",
-        "read-package-json-fast": "^2.0.2",
+        "read-package-json": "^5.0.0",
+        "read-package-json-fast": "^2.0.3",
         "readdir-scoped-modules": "^1.1.0",
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
         "ssri": "^8.0.1",
-        "tar": "^6.1.0",
+        "tar": "^6.1.11",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "treeverse": "^1.0.4",
-        "validate-npm-package-name": "~3.0.0",
+        "validate-npm-package-name": "^4.0.0",
         "which": "^2.0.2",
-        "write-file-atomic": "^3.0.3"
+        "write-file-atomic": "^4.0.1"
       },
       "dependencies": {
+        "@gar/promisify": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "@isaacs/string-locale-compare": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
         "@npmcli/arborist": {
-          "version": "2.7.1",
+          "version": "5.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
+            "@isaacs/string-locale-compare": "^1.1.0",
             "@npmcli/installed-package-contents": "^1.0.7",
-            "@npmcli/map-workspaces": "^1.0.2",
-            "@npmcli/metavuln-calculator": "^1.1.0",
+            "@npmcli/map-workspaces": "^2.0.0",
+            "@npmcli/metavuln-calculator": "^3.0.1",
             "@npmcli/move-file": "^1.1.0",
             "@npmcli/name-from-folder": "^1.0.1",
-            "@npmcli/node-gyp": "^1.0.1",
+            "@npmcli/node-gyp": "^1.0.3",
             "@npmcli/package-json": "^1.0.1",
-            "@npmcli/run-script": "^1.8.2",
-            "bin-links": "^2.2.1",
-            "cacache": "^15.0.3",
+            "@npmcli/run-script": "^3.0.0",
+            "bin-links": "^3.0.0",
+            "cacache": "^16.0.0",
             "common-ancestor-path": "^1.0.1",
             "json-parse-even-better-errors": "^2.3.1",
             "json-stringify-nice": "^1.1.4",
             "mkdirp": "^1.0.4",
             "mkdirp-infer-owner": "^2.0.0",
+            "nopt": "^5.0.0",
             "npm-install-checks": "^4.0.0",
-            "npm-package-arg": "^8.1.0",
-            "npm-pick-manifest": "^6.1.0",
-            "npm-registry-fetch": "^11.0.0",
-            "pacote": "^11.2.6",
-            "parse-conflict-json": "^1.1.1",
-            "proc-log": "^1.0.0",
+            "npm-package-arg": "^9.0.0",
+            "npm-pick-manifest": "^7.0.0",
+            "npm-registry-fetch": "^13.0.0",
+            "npmlog": "^6.0.1",
+            "pacote": "^13.0.5",
+            "parse-conflict-json": "^2.0.1",
+            "proc-log": "^2.0.0",
             "promise-all-reject-late": "^1.0.0",
             "promise-call-limit": "^1.0.1",
             "read-package-json-fast": "^2.0.2",
@@ -24949,25 +25055,27 @@
             "rimraf": "^3.0.2",
             "semver": "^7.3.5",
             "ssri": "^8.0.1",
-            "tar": "^6.1.0",
             "treeverse": "^1.0.4",
             "walk-up-path": "^1.0.0"
           }
         },
         "@npmcli/ci-detect": {
-          "version": "1.3.0",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
         "@npmcli/config": {
-          "version": "2.2.0",
+          "version": "4.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
+            "@npmcli/map-workspaces": "^2.0.1",
             "ini": "^2.0.0",
             "mkdirp-infer-owner": "^2.0.0",
             "nopt": "^5.0.0",
-            "semver": "^7.3.4",
+            "proc-log": "^2.0.0",
+            "read-package-json-fast": "^2.0.3",
+            "semver": "^7.3.5",
             "walk-up-path": "^1.0.0"
           }
         },
@@ -24979,15 +25087,25 @@
             "ansi-styles": "^4.3.0"
           }
         },
-        "@npmcli/git": {
+        "@npmcli/fs": {
           "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
+            "@gar/promisify": "^1.1.3",
+            "semver": "^7.3.5"
+          }
+        },
+        "@npmcli/git": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
             "@npmcli/promise-spawn": "^1.3.2",
-            "lru-cache": "^6.0.0",
+            "lru-cache": "^7.3.1",
             "mkdirp": "^1.0.4",
-            "npm-pick-manifest": "^6.1.1",
+            "npm-pick-manifest": "^7.0.0",
+            "proc-log": "^2.0.0",
             "promise-inflight": "^1.0.1",
             "promise-retry": "^2.0.1",
             "semver": "^7.3.5",
@@ -25004,24 +25122,43 @@
           }
         },
         "@npmcli/map-workspaces": {
-          "version": "1.0.3",
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/name-from-folder": "^1.0.1",
-            "glob": "^7.1.6",
-            "minimatch": "^3.0.4",
-            "read-package-json-fast": "^2.0.1"
+            "glob": "^7.2.0",
+            "minimatch": "^5.0.1",
+            "read-package-json-fast": "^2.0.3"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "balanced-match": "^1.0.0"
+              }
+            },
+            "minimatch": {
+              "version": "5.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^2.0.1"
+              }
+            }
           }
         },
         "@npmcli/metavuln-calculator": {
-          "version": "1.1.1",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cacache": "^15.0.5",
-            "pacote": "^11.1.11",
-            "semver": "^7.3.2"
+            "cacache": "^16.0.0",
+            "json-parse-even-better-errors": "^2.3.1",
+            "pacote": "^13.0.3",
+            "semver": "^7.3.5"
           }
         },
         "@npmcli/move-file": {
@@ -25039,7 +25176,7 @@
           "dev": true
         },
         "@npmcli/node-gyp": {
-          "version": "1.0.2",
+          "version": "1.0.3",
           "bundled": true,
           "dev": true
         },
@@ -25060,19 +25197,18 @@
           }
         },
         "@npmcli/run-script": {
-          "version": "1.8.5",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/node-gyp": "^1.0.2",
+            "@npmcli/node-gyp": "^1.0.3",
             "@npmcli/promise-spawn": "^1.3.2",
-            "infer-owner": "^1.0.4",
-            "node-gyp": "^7.1.0",
-            "read-package-json-fast": "^2.0.1"
+            "node-gyp": "^9.0.0",
+            "read-package-json-fast": "^2.0.3"
           }
         },
         "@tootallnate/once": {
-          "version": "1.1.2",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
@@ -25090,7 +25226,7 @@
           }
         },
         "agentkeepalive": {
-          "version": "4.1.4",
+          "version": "4.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25108,19 +25244,8 @@
             "indent-string": "^4.0.0"
           }
         },
-        "ajv": {
-          "version": "6.12.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
         "ansi-regex": {
-          "version": "2.1.1",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true
         },
@@ -25153,44 +25278,16 @@
           "dev": true
         },
         "are-we-there-yet": {
-          "version": "1.1.5",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "readable-stream": "^3.6.0"
           }
         },
         "asap": {
           "version": "2.0.6",
-          "bundled": true,
-          "dev": true
-        },
-        "asn1": {
-          "version": "0.2.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safer-buffer": "~2.1.0"
-          }
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "bundled": true,
-          "dev": true
-        },
-        "aws4": {
-          "version": "1.11.0",
           "bundled": true,
           "dev": true
         },
@@ -25199,25 +25296,17 @@
           "bundled": true,
           "dev": true
         },
-        "bcrypt-pbkdf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "tweetnacl": "^0.14.3"
-          }
-        },
         "bin-links": {
-          "version": "2.2.1",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "cmd-shim": "^4.0.1",
-            "mkdirp": "^1.0.3",
+            "mkdirp-infer-owner": "^2.0.0",
             "npm-normalize-package-bin": "^1.0.0",
             "read-cmd-shim": "^2.0.0",
             "rimraf": "^3.0.0",
-            "write-file-atomic": "^3.0.3"
+            "write-file-atomic": "^4.0.0"
           }
         },
         "binary-extensions": {
@@ -25235,46 +25324,40 @@
           }
         },
         "builtins": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "byte-size": {
-          "version": "7.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "cacache": {
-          "version": "15.2.0",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/move-file": "^1.0.1",
+            "semver": "^7.0.0"
+          }
+        },
+        "cacache": {
+          "version": "16.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/fs": "^2.1.0",
+            "@npmcli/move-file": "^1.1.2",
             "chownr": "^2.0.0",
-            "fs-minipass": "^2.0.0",
-            "glob": "^7.1.4",
+            "fs-minipass": "^2.1.0",
+            "glob": "^7.2.0",
             "infer-owner": "^1.0.4",
-            "lru-cache": "^6.0.0",
-            "minipass": "^3.1.1",
+            "lru-cache": "^7.7.1",
+            "minipass": "^3.1.6",
             "minipass-collect": "^1.0.2",
             "minipass-flush": "^1.0.5",
-            "minipass-pipeline": "^1.2.2",
-            "mkdirp": "^1.0.3",
+            "minipass-pipeline": "^1.2.4",
+            "mkdirp": "^1.0.4",
             "p-map": "^4.0.0",
             "promise-inflight": "^1.0.1",
             "rimraf": "^3.0.2",
             "ssri": "^8.0.1",
-            "tar": "^6.0.2",
+            "tar": "^6.1.11",
             "unique-filename": "^1.1.1"
           }
         },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true,
-          "dev": true
-        },
         "chalk": {
-          "version": "4.1.1",
+          "version": "4.1.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25301,52 +25384,21 @@
           "dev": true
         },
         "cli-columns": {
-          "version": "3.1.2",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "^2.0.0",
-            "strip-ansi": "^3.0.1"
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1"
           }
         },
         "cli-table3": {
-          "version": "0.6.0",
+          "version": "0.6.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "colors": "^1.1.2",
-            "object-assign": "^4.1.0",
+            "colors": "1.4.0",
             "string-width": "^4.2.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "5.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "string-width": {
-              "version": "4.2.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "6.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^5.0.0"
-              }
-            }
           }
         },
         "clone": {
@@ -25362,11 +25414,6 @@
             "mkdirp-infer-owner": "^2.0.0"
           }
         },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
         "color-convert": {
           "version": "2.0.1",
           "bundled": true,
@@ -25380,6 +25427,11 @@
           "bundled": true,
           "dev": true
         },
+        "color-support": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true
+        },
         "colors": {
           "version": "1.4.0",
           "bundled": true,
@@ -25387,20 +25439,12 @@
           "optional": true
         },
         "columnify": {
-          "version": "1.5.4",
+          "version": "1.6.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "strip-ansi": "^3.0.0",
+            "strip-ansi": "^6.0.1",
             "wcwidth": "^1.0.0"
-          }
-        },
-        "combined-stream": {
-          "version": "1.0.8",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "delayed-stream": "~1.0.0"
           }
         },
         "common-ancestor-path": {
@@ -25418,21 +25462,8 @@
           "bundled": true,
           "dev": true
         },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "^1.0.0"
-          }
-        },
         "debug": {
-          "version": "4.3.1",
+          "version": "4.3.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25459,11 +25490,6 @@
             "clone": "^1.0.2"
           }
         },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
@@ -25487,15 +25513,6 @@
           "version": "5.0.0",
           "bundled": true,
           "dev": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.1.0"
-          }
         },
         "emoji-regex": {
           "version": "8.0.0",
@@ -25521,28 +25538,8 @@
           "bundled": true,
           "dev": true
         },
-        "extend": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "bundled": true,
-          "dev": true
-        },
-        "fast-json-stable-stringify": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
+        "fastest-levenshtein": {
+          "version": "1.0.12",
           "bundled": true,
           "dev": true
         },
@@ -25565,55 +25562,22 @@
           "dev": true
         },
         "gauge": {
-          "version": "2.7.4",
+          "version": "4.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "^1.0.0"
+            "aproba": "^1.0.3 || ^2.0.0",
+            "color-support": "^1.1.3",
+            "console-control-strings": "^1.1.0",
+            "has-unicode": "^2.0.1",
+            "signal-exit": "^3.0.7",
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1",
+            "wide-align": "^1.1.5"
           }
         },
         "glob": {
-          "version": "7.1.7",
+          "version": "7.2.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25626,23 +25590,9 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.6",
+          "version": "4.2.9",
           "bundled": true,
           "dev": true
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "har-validator": {
-          "version": "5.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ajv": "^6.12.3",
-            "har-schema": "^2.0.0"
-          }
         },
         "has": {
           "version": "1.0.3",
@@ -25663,11 +25613,11 @@
           "dev": true
         },
         "hosted-git-info": {
-          "version": "4.0.2",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "^6.0.0"
+            "lru-cache": "^7.5.1"
           }
         },
         "http-cache-semantics": {
@@ -25676,23 +25626,13 @@
           "dev": true
         },
         "http-proxy-agent": {
-          "version": "4.0.1",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@tootallnate/once": "1",
+            "@tootallnate/once": "2",
             "agent-base": "6",
             "debug": "4"
-          }
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "^1.0.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
           }
         },
         "https-proxy-agent": {
@@ -25722,7 +25662,7 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.4",
+          "version": "4.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25764,18 +25704,17 @@
           "dev": true
         },
         "init-package-json": {
-          "version": "2.0.3",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "^7.1.1",
-            "npm-package-arg": "^8.1.2",
+            "npm-package-arg": "^9.0.1",
             "promzard": "^0.3.0",
-            "read": "~1.0.1",
-            "read-package-json": "^3.0.1",
+            "read": "^1.0.7",
+            "read-package-json": "^5.0.0",
             "semver": "^7.3.5",
             "validate-npm-package-license": "^3.0.4",
-            "validate-npm-package-name": "^3.0.0"
+            "validate-npm-package-name": "^4.0.0"
           }
         },
         "ip": {
@@ -25797,7 +25736,7 @@
           }
         },
         "is-core-module": {
-          "version": "2.4.0",
+          "version": "2.8.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25805,7 +25744,7 @@
           }
         },
         "is-fullwidth-code-point": {
-          "version": "2.0.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true
         },
@@ -25814,28 +25753,8 @@
           "bundled": true,
           "dev": true
         },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
           "bundled": true,
           "dev": true
         },
@@ -25844,23 +25763,8 @@
           "bundled": true,
           "dev": true
         },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "bundled": true,
-          "dev": true
-        },
         "json-stringify-nice": {
           "version": "1.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
           "bundled": true,
           "dev": true
         },
@@ -25869,45 +25773,29 @@
           "bundled": true,
           "dev": true
         },
-        "jsprim": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
         "just-diff": {
-          "version": "3.1.1",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true
         },
         "just-diff-apply": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "leven": {
-          "version": "3.1.0",
+          "version": "5.2.0",
           "bundled": true,
           "dev": true
         },
         "libnpmaccess": {
-          "version": "4.0.3",
+          "version": "6.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "minipass": "^3.1.1",
-            "npm-package-arg": "^8.1.2",
-            "npm-registry-fetch": "^11.0.0"
+            "npm-package-arg": "^9.0.1",
+            "npm-registry-fetch": "^13.0.0"
           }
         },
         "libnpmdiff": {
-          "version": "2.0.4",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25916,152 +25804,138 @@
             "binary-extensions": "^2.2.0",
             "diff": "^5.0.0",
             "minimatch": "^3.0.4",
-            "npm-package-arg": "^8.1.4",
-            "pacote": "^11.3.4",
+            "npm-package-arg": "^9.0.1",
+            "pacote": "^13.0.5",
             "tar": "^6.1.0"
           }
         },
         "libnpmexec": {
-          "version": "2.0.0",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^2.3.0",
-            "@npmcli/ci-detect": "^1.3.0",
-            "@npmcli/run-script": "^1.8.4",
+            "@npmcli/arborist": "^5.0.0",
+            "@npmcli/ci-detect": "^2.0.0",
+            "@npmcli/run-script": "^3.0.0",
             "chalk": "^4.1.0",
             "mkdirp-infer-owner": "^2.0.0",
-            "npm-package-arg": "^8.1.2",
-            "pacote": "^11.3.1",
-            "proc-log": "^1.0.0",
+            "npm-package-arg": "^9.0.1",
+            "npmlog": "^6.0.1",
+            "pacote": "^13.0.5",
+            "proc-log": "^2.0.0",
             "read": "^1.0.7",
             "read-package-json-fast": "^2.0.2",
             "walk-up-path": "^1.0.0"
           }
         },
         "libnpmfund": {
-          "version": "1.1.0",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^2.5.0"
+            "@npmcli/arborist": "^5.0.0"
           }
         },
         "libnpmhook": {
-          "version": "6.0.3",
+          "version": "8.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
-            "npm-registry-fetch": "^11.0.0"
+            "npm-registry-fetch": "^13.0.0"
           }
         },
         "libnpmorg": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "^2.0.0",
-            "npm-registry-fetch": "^11.0.0"
-          }
-        },
-        "libnpmpack": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@npmcli/run-script": "^1.8.3",
-            "npm-package-arg": "^8.1.0",
-            "pacote": "^11.2.6"
-          }
-        },
-        "libnpmpublish": {
           "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "normalize-package-data": "^3.0.2",
-            "npm-package-arg": "^8.1.2",
-            "npm-registry-fetch": "^11.0.0",
+            "aproba": "^2.0.0",
+            "npm-registry-fetch": "^13.0.0"
+          }
+        },
+        "libnpmpack": {
+          "version": "4.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/run-script": "^3.0.0",
+            "npm-package-arg": "^9.0.1",
+            "pacote": "^13.0.5"
+          }
+        },
+        "libnpmpublish": {
+          "version": "6.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "normalize-package-data": "^4.0.0",
+            "npm-package-arg": "^9.0.1",
+            "npm-registry-fetch": "^13.0.0",
             "semver": "^7.1.3",
             "ssri": "^8.0.1"
           }
         },
         "libnpmsearch": {
-          "version": "3.1.2",
+          "version": "5.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-registry-fetch": "^11.0.0"
+            "npm-registry-fetch": "^13.0.0"
           }
         },
         "libnpmteam": {
-          "version": "2.0.4",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
-            "npm-registry-fetch": "^11.0.0"
+            "npm-registry-fetch": "^13.0.0"
           }
         },
         "libnpmversion": {
-          "version": "1.2.1",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/git": "^2.0.7",
-            "@npmcli/run-script": "^1.8.4",
+            "@npmcli/git": "^3.0.0",
+            "@npmcli/run-script": "^3.0.0",
             "json-parse-even-better-errors": "^2.3.1",
+            "proc-log": "^2.0.0",
             "semver": "^7.3.5",
             "stringify-package": "^1.0.1"
           }
         },
         "lru-cache": {
-          "version": "6.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "make-fetch-happen": {
-          "version": "9.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "agentkeepalive": "^4.1.3",
-            "cacache": "^15.2.0",
-            "http-cache-semantics": "^4.1.0",
-            "http-proxy-agent": "^4.0.1",
-            "https-proxy-agent": "^5.0.0",
-            "is-lambda": "^1.0.1",
-            "lru-cache": "^6.0.0",
-            "minipass": "^3.1.3",
-            "minipass-collect": "^1.0.2",
-            "minipass-fetch": "^1.3.2",
-            "minipass-flush": "^1.0.5",
-            "minipass-pipeline": "^1.2.4",
-            "negotiator": "^0.6.2",
-            "promise-retry": "^2.0.1",
-            "socks-proxy-agent": "^5.0.0",
-            "ssri": "^8.0.0"
-          }
-        },
-        "mime-db": {
-          "version": "1.48.0",
+          "version": "7.7.1",
           "bundled": true,
           "dev": true
         },
-        "mime-types": {
-          "version": "2.1.31",
+        "make-fetch-happen": {
+          "version": "10.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "mime-db": "1.48.0"
+            "agentkeepalive": "^4.2.1",
+            "cacache": "^16.0.2",
+            "http-cache-semantics": "^4.1.0",
+            "http-proxy-agent": "^5.0.0",
+            "https-proxy-agent": "^5.0.0",
+            "is-lambda": "^1.0.1",
+            "lru-cache": "^7.7.1",
+            "minipass": "^3.1.6",
+            "minipass-collect": "^1.0.2",
+            "minipass-fetch": "^2.0.3",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.4",
+            "negotiator": "^0.6.3",
+            "promise-retry": "^2.0.1",
+            "socks-proxy-agent": "^6.1.1",
+            "ssri": "^8.0.1"
           }
         },
         "minimatch": {
-          "version": "3.0.4",
+          "version": "3.1.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26069,7 +25943,7 @@
           }
         },
         "minipass": {
-          "version": "3.1.3",
+          "version": "3.1.6",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26085,14 +25959,14 @@
           }
         },
         "minipass-fetch": {
-          "version": "1.3.4",
+          "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "encoding": "^0.1.12",
-            "minipass": "^3.1.0",
+            "encoding": "^0.1.13",
+            "minipass": "^3.1.6",
             "minipass-sized": "^1.0.3",
-            "minizlib": "^2.0.0"
+            "minizlib": "^2.1.2"
           }
         },
         "minipass-flush": {
@@ -26163,24 +26037,24 @@
           "dev": true
         },
         "negotiator": {
-          "version": "0.6.2",
+          "version": "0.6.3",
           "bundled": true,
           "dev": true
         },
         "node-gyp": {
-          "version": "7.1.2",
+          "version": "9.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "env-paths": "^2.2.0",
             "glob": "^7.1.4",
-            "graceful-fs": "^4.2.3",
+            "graceful-fs": "^4.2.6",
+            "make-fetch-happen": "^10.0.3",
             "nopt": "^5.0.0",
-            "npmlog": "^4.1.2",
-            "request": "^2.88.2",
+            "npmlog": "^6.0.0",
             "rimraf": "^3.0.2",
-            "semver": "^7.3.2",
-            "tar": "^6.0.2",
+            "semver": "^7.3.5",
+            "tar": "^6.1.2",
             "which": "^2.0.2"
           }
         },
@@ -26193,18 +26067,18 @@
           }
         },
         "normalize-package-data": {
-          "version": "3.0.2",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "^4.0.1",
-            "resolve": "^1.20.0",
-            "semver": "^7.3.4",
-            "validate-npm-package-license": "^3.0.1"
+            "hosted-git-info": "^5.0.0",
+            "is-core-module": "^2.8.1",
+            "semver": "^7.3.5",
+            "validate-npm-package-license": "^3.0.4"
           }
         },
         "npm-audit-report": {
-          "version": "2.1.5",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26233,56 +26107,58 @@
           "dev": true
         },
         "npm-package-arg": {
-          "version": "8.1.5",
+          "version": "9.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "^4.0.1",
-            "semver": "^7.3.4",
-            "validate-npm-package-name": "^3.0.0"
+            "hosted-git-info": "^5.0.0",
+            "semver": "^7.3.5",
+            "validate-npm-package-name": "^4.0.0"
           }
         },
         "npm-packlist": {
-          "version": "2.2.2",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "^7.1.6",
-            "ignore-walk": "^3.0.3",
-            "npm-bundled": "^1.1.1",
+            "glob": "^7.2.0",
+            "ignore-walk": "^4.0.1",
+            "npm-bundled": "^1.1.2",
             "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "npm-pick-manifest": {
-          "version": "6.1.1",
+          "version": "7.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "npm-install-checks": "^4.0.0",
             "npm-normalize-package-bin": "^1.0.1",
-            "npm-package-arg": "^8.1.2",
-            "semver": "^7.3.4"
+            "npm-package-arg": "^9.0.0",
+            "semver": "^7.3.5"
           }
         },
         "npm-profile": {
-          "version": "5.0.4",
+          "version": "6.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-registry-fetch": "^11.0.0"
+            "npm-registry-fetch": "^13.0.0",
+            "proc-log": "^2.0.0"
           }
         },
         "npm-registry-fetch": {
-          "version": "11.0.0",
+          "version": "13.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "make-fetch-happen": "^9.0.1",
-            "minipass": "^3.1.3",
-            "minipass-fetch": "^1.3.0",
+            "make-fetch-happen": "^10.0.6",
+            "minipass": "^3.1.6",
+            "minipass-fetch": "^2.0.3",
             "minipass-json-stream": "^1.0.1",
-            "minizlib": "^2.0.0",
-            "npm-package-arg": "^8.0.0"
+            "minizlib": "^2.1.2",
+            "npm-package-arg": "^9.0.1",
+            "proc-log": "^2.0.0"
           }
         },
         "npm-user-validate": {
@@ -26291,30 +26167,15 @@
           "dev": true
         },
         "npmlog": {
-          "version": "4.1.2",
+          "version": "6.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "^3.0.0",
+            "console-control-strings": "^1.1.0",
+            "gauge": "^4.0.0",
+            "set-blocking": "^2.0.0"
           }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.9.0",
-          "bundled": true,
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
         },
         "once": {
           "version": "1.4.0",
@@ -26338,39 +26199,41 @@
           }
         },
         "pacote": {
-          "version": "11.3.5",
+          "version": "13.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/git": "^2.1.0",
-            "@npmcli/installed-package-contents": "^1.0.6",
+            "@npmcli/git": "^3.0.0",
+            "@npmcli/installed-package-contents": "^1.0.7",
             "@npmcli/promise-spawn": "^1.2.0",
-            "@npmcli/run-script": "^1.8.2",
-            "cacache": "^15.0.5",
+            "@npmcli/run-script": "^3.0.1",
+            "cacache": "^16.0.0",
             "chownr": "^2.0.0",
             "fs-minipass": "^2.1.0",
             "infer-owner": "^1.0.4",
-            "minipass": "^3.1.3",
-            "mkdirp": "^1.0.3",
-            "npm-package-arg": "^8.0.1",
-            "npm-packlist": "^2.1.4",
-            "npm-pick-manifest": "^6.0.0",
-            "npm-registry-fetch": "^11.0.0",
+            "minipass": "^3.1.6",
+            "mkdirp": "^1.0.4",
+            "npm-package-arg": "^9.0.0",
+            "npm-packlist": "^4.0.0",
+            "npm-pick-manifest": "^7.0.0",
+            "npm-registry-fetch": "^13.0.1",
+            "proc-log": "^2.0.0",
             "promise-retry": "^2.0.1",
-            "read-package-json-fast": "^2.0.1",
+            "read-package-json": "^5.0.0",
+            "read-package-json-fast": "^2.0.3",
             "rimraf": "^3.0.2",
             "ssri": "^8.0.1",
-            "tar": "^6.1.0"
+            "tar": "^6.1.11"
           }
         },
         "parse-conflict-json": {
-          "version": "1.1.1",
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "json-parse-even-better-errors": "^2.3.0",
-            "just-diff": "^3.0.1",
-            "just-diff-apply": "^3.0.0"
+            "json-parse-even-better-errors": "^2.3.1",
+            "just-diff": "^5.0.1",
+            "just-diff-apply": "^5.2.0"
           }
         },
         "path-is-absolute": {
@@ -26378,22 +26241,7 @@
           "bundled": true,
           "dev": true
         },
-        "path-parse": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "performance-now": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
-        },
         "proc-log": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "process-nextick-args": {
           "version": "2.0.1",
           "bundled": true,
           "dev": true
@@ -26430,23 +26278,8 @@
             "read": "1"
           }
         },
-        "psl": {
-          "version": "1.8.0",
-          "bundled": true,
-          "dev": true
-        },
-        "punycode": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
         "qrcode-terminal": {
           "version": "0.12.0",
-          "bundled": true,
-          "dev": true
-        },
-        "qs": {
-          "version": "6.5.2",
           "bundled": true,
           "dev": true
         },
@@ -26464,18 +26297,18 @@
           "dev": true
         },
         "read-package-json": {
-          "version": "3.0.1",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "^7.1.1",
-            "json-parse-even-better-errors": "^2.3.0",
-            "normalize-package-data": "^3.0.0",
-            "npm-normalize-package-bin": "^1.0.0"
+            "glob": "^7.2.0",
+            "json-parse-even-better-errors": "^2.3.1",
+            "normalize-package-data": "^4.0.0",
+            "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "read-package-json-fast": {
-          "version": "2.0.2",
+          "version": "2.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26484,17 +26317,13 @@
           }
         },
         "readable-stream": {
-          "version": "2.3.7",
+          "version": "3.6.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         },
         "readdir-scoped-modules": {
@@ -26506,63 +26335,6 @@
             "dezalgo": "^1.0.0",
             "graceful-fs": "^4.1.2",
             "once": "^1.3.0"
-          }
-        },
-        "request": {
-          "version": "2.88.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.3",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.5.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
-          },
-          "dependencies": {
-            "form-data": {
-              "version": "2.3.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
-              }
-            },
-            "tough-cookie": {
-              "version": "2.5.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
-              }
-            }
-          }
-        },
-        "resolve": {
-          "version": "1.20.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
           }
         },
         "retry": {
@@ -26579,14 +26351,15 @@
           }
         },
         "safe-buffer": {
-          "version": "5.1.2",
+          "version": "5.2.1",
           "bundled": true,
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "7.3.5",
@@ -26594,6 +26367,16 @@
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "6.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            }
           }
         },
         "set-blocking": {
@@ -26602,32 +26385,32 @@
           "dev": true
         },
         "signal-exit": {
-          "version": "3.0.3",
+          "version": "3.0.7",
           "bundled": true,
           "dev": true
         },
         "smart-buffer": {
-          "version": "4.1.0",
+          "version": "4.2.0",
           "bundled": true,
           "dev": true
         },
         "socks": {
-          "version": "2.6.1",
+          "version": "2.6.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "ip": "^1.1.5",
-            "smart-buffer": "^4.1.0"
+            "smart-buffer": "^4.2.0"
           }
         },
         "socks-proxy-agent": {
-          "version": "5.0.0",
+          "version": "6.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "6",
-            "debug": "4",
-            "socks": "^2.3.3"
+            "agent-base": "^6.0.2",
+            "debug": "^4.3.1",
+            "socks": "^2.6.1"
           }
         },
         "spdx-correct": {
@@ -26654,25 +26437,9 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.9",
+          "version": "3.0.11",
           "bundled": true,
           "dev": true
-        },
-        "sshpk": {
-          "version": "1.16.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.0.2",
-            "tweetnacl": "~0.14.0"
-          }
         },
         "ssri": {
           "version": "8.0.1",
@@ -26683,35 +26450,21 @@
           }
         },
         "string-width": {
-          "version": "2.1.1",
+          "version": "4.2.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
           }
         },
         "string_decoder": {
-          "version": "1.1.1",
+          "version": "1.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "~5.2.0"
           }
         },
         "stringify-package": {
@@ -26720,11 +26473,11 @@
           "dev": true
         },
         "strip-ansi": {
-          "version": "3.0.1",
+          "version": "6.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "^5.0.1"
           }
         },
         "supports-color": {
@@ -26733,6 +26486,19 @@
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
+          }
+        },
+        "tar": {
+          "version": "6.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "minipass": "^3.0.0",
+            "minizlib": "^2.1.1",
+            "mkdirp": "^1.0.3",
+            "yallist": "^4.0.0"
           }
         },
         "text-table": {
@@ -26750,27 +26516,6 @@
           "bundled": true,
           "dev": true
         },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "dev": true
-        },
-        "typedarray-to-buffer": {
-          "version": "3.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-typedarray": "^1.0.0"
-          }
-        },
         "unique-filename": {
           "version": "1.1.1",
           "bundled": true,
@@ -26787,21 +26532,8 @@
             "imurmurhash": "^0.1.4"
           }
         },
-        "uri-js": {
-          "version": "4.4.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "punycode": "^2.1.0"
-          }
-        },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.4.0",
           "bundled": true,
           "dev": true
         },
@@ -26815,21 +26547,11 @@
           }
         },
         "validate-npm-package-name": {
-          "version": "3.0.0",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "builtins": "^1.0.3"
-          }
-        },
-        "verror": {
-          "version": "1.10.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "^1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "^1.2.0"
+            "builtins": "^5.0.0"
           }
         },
         "walk-up-path": {
@@ -26854,11 +26576,11 @@
           }
         },
         "wide-align": {
-          "version": "1.1.3",
+          "version": "1.1.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "^1.0.2 || 2"
+            "string-width": "^1.0.2 || 2 || 3 || 4"
           }
         },
         "wrappy": {
@@ -26867,14 +26589,12 @@
           "dev": true
         },
         "write-file-atomic": {
-          "version": "3.0.3",
+          "version": "4.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4",
-            "is-typedarray": "^1.0.0",
-            "signal-exit": "^3.0.2",
-            "typedarray-to-buffer": "^3.1.5"
+            "signal-exit": "^3.0.7"
           }
         },
         "yallist": {
@@ -27534,9 +27254,9 @@
       },
       "dependencies": {
         "qs": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
-          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "version": "6.10.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+          "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
           "dev": true,
           "requires": {
             "side-channel": "^1.0.4"
@@ -30875,16 +30595,16 @@
       }
     },
     "semantic-release": {
-      "version": "17.4.4",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.4.4.tgz",
-      "integrity": "sha512-fQIA0lw2Sy/9+TcoM/BxyzKCSwdUd8EPRwGoOuBLgxKigPCY6kaKs8TOsgUVy6QrlTYwni2yzbMb5Q2107P9eA==",
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.2.tgz",
+      "integrity": "sha512-7tPonjZxukKECmClhsfyMKDt0GR38feIC2HxgyYaBi+9tDySBLjK/zYDLhh+m6yjnHIJa9eBTKYE7k63ZQcYbw==",
       "dev": true,
       "requires": {
-        "@semantic-release/commit-analyzer": "^8.0.0",
-        "@semantic-release/error": "^2.2.0",
-        "@semantic-release/github": "^7.0.0",
-        "@semantic-release/npm": "^7.0.0",
-        "@semantic-release/release-notes-generator": "^9.0.0",
+        "@semantic-release/commit-analyzer": "^9.0.2",
+        "@semantic-release/error": "^3.0.0",
+        "@semantic-release/github": "^8.0.0",
+        "@semantic-release/npm": "^9.0.0",
+        "@semantic-release/release-notes-generator": "^10.0.0",
         "aggregate-error": "^3.0.0",
         "cosmiconfig": "^7.0.0",
         "debug": "^4.0.0",
@@ -30897,8 +30617,8 @@
         "hook-std": "^2.0.0",
         "hosted-git-info": "^4.0.0",
         "lodash": "^4.17.21",
-        "marked": "^2.0.0",
-        "marked-terminal": "^4.1.1",
+        "marked": "^4.0.10",
+        "marked-terminal": "^5.0.0",
         "micromatch": "^4.0.2",
         "p-each-series": "^2.1.0",
         "p-reduce": "^2.0.0",
@@ -30911,9 +30631,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "ansi-styles": {
@@ -30952,9 +30672,9 @@
           "dev": true
         },
         "cosmiconfig": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
-          "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+          "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
           "dev": true,
           "requires": {
             "@types/parse-json": "^4.0.0",
@@ -31021,9 +30741,9 @@
           "dev": true
         },
         "hosted-git-info": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
-          "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+          "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -31042,9 +30762,9 @@
           "dev": true
         },
         "is-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
           "dev": true
         },
         "mimic-fn": {
@@ -31145,12 +30865,20 @@
           }
         },
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "version": "7.3.6",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+          "integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
           "dev": true,
           "requires": {
-            "lru-cache": "^6.0.0"
+            "lru-cache": "^7.4.0"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "7.8.1",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
+              "integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg==",
+              "dev": true
+            }
           }
         },
         "shebang-command": {
@@ -31169,23 +30897,23 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
+            "strip-ansi": "^6.0.1"
           }
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         },
         "which": {
@@ -31238,21 +30966,21 @@
       }
     },
     "semantic-release-gitmoji": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/semantic-release-gitmoji/-/semantic-release-gitmoji-1.3.4.tgz",
-      "integrity": "sha512-uuuEmlhCwnSm3KMhu/bO2TMza/Fh8tZ8XVarHBVOVReSoGlJZKXn/TI1BSCgs2iPaxEJM3yJQ/zVCJISwfPtrQ==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/semantic-release-gitmoji/-/semantic-release-gitmoji-1.4.4.tgz",
+      "integrity": "sha512-Bwt8fCjEw7upLcEsPNUwRIGfjIqM+Uinds5F0BrywvRe4SnDGr1XV5HzyCrVffV+oxg6KjmMQsmz8vjz8pTaVg==",
       "dev": true,
       "requires": {
         "dateformat": "^3.0.3",
-        "debug": "^4.1.1",
-        "emoji-regex": "^9.0.0",
-        "git-url-parse": "^11.1.2",
+        "debug": "^4.3.2",
+        "emoji-regex": "^9.2.2",
+        "git-url-parse": "^11.5.0",
         "handlebars": "^4.7.6",
         "issue-regex": "^3.1.0",
         "lodash.clonedeep": "^4.5.0",
         "lodash.mergewith": "^4.6.2",
         "lodash.uniq": "^4.5.0",
-        "node-emoji": "^1.10.0"
+        "node-emoji": "^1.11.0"
       },
       "dependencies": {
         "dateformat": {
@@ -32856,9 +32584,9 @@
           "dev": true
         },
         "is-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
           "dev": true
         },
         "rimraf": {
@@ -33320,12 +33048,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
       "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
-      "dev": true
-    },
-    "trim-off-newlines": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.3.tgz",
-      "integrity": "sha512-kh6Tu6GbeSNMGfrrZh6Bb/4ZEHV1QlB4xNDBeog8Y9/QwFlKTRyWvY3Fs9tRDAMZliVUwieMgEdIeL/FtqjkJg==",
       "dev": true
     },
     "trim-trailing-lines": {
@@ -34651,6 +34373,7 @@
       "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.3.tgz",
       "integrity": "sha512-7vKN45IxsKxe5GcVCbc2qFU5aWzyiLrYJyUuMz4BQLKctCj/fmCa0w6fGiiQ2cLFetNcek1ppGJQDCup0c1hpA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "chalk": "^4.1.0",
         "hash-sum": "^2.0.0",
@@ -34662,6 +34385,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -34671,6 +34395,7 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -34681,6 +34406,7 @@
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -34689,25 +34415,29 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "hash-sum": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
           "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "has-flag": "^4.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "raw-loader": "4.0.2",
     "react-is": "^17.0.2",
     "sass-loader": "10.2.0",
-    "semantic-release": "^17.4.4",
+    "semantic-release": "^19.0.2",
     "semantic-release-gitmoji": "^1.4.4",
     "svg-url-loader": "^7.1.1",
     "typescript": "~4.1.5",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "react-is": "^17.0.2",
     "sass-loader": "10.2.0",
     "semantic-release": "^17.4.4",
-    "semantic-release-gitmoji": "^1.3.4",
+    "semantic-release-gitmoji": "^1.4.4",
     "svg-url-loader": "^7.1.1",
     "typescript": "~4.1.5",
     "vue-code-highlight": "^0.7.8",


### PR DESCRIPTION
## Details
The dependencies  used for our release workflow were updated because sometimes the workflow doesn't work as expected with some Gitmoji's like ♻️ 

## Related tickets
/

## Main changes
- Upgrade semantic-release-gitmoji to v1.4.4
- Upgrade semantic-release to v19.0.2