### PR TITLE
🐛 [VIEW-734] Prevent Google Maps JS SDK from importing more than one time

### DIFF
--- a/src/services/googleAPI.js
+++ b/src/services/googleAPI.js
@@ -10,13 +10,16 @@ export function getGoogleAPI(key) {
   mapsApiPromise = new Promise((resolve) => {
     // Check Google Maps version documentation: https://developers.google.com/maps/documentation/javascript/versions
     const version = '3.42';
-    loadScript({
-      url: `https://maps.googleapis.com/maps/api/js?v=${version}&key=${key}&libraries=places&region=DE`,
-    }).then(() => {
-      resolve(window.google);
-    }).catch(() => {
-      mapsApiPromise = null;
-    });
+    const url = `https://maps.googleapis.com/maps/api/js?v=${version}&key=${key}&libraries=places&region=DE`;
+    if (document.querySelector(`script[src="${url}"]`)) {
+      resolve();
+    } else {
+      loadScript({ url }).then(() => {
+        resolve(window.google);
+      }).catch(() => {
+        mapsApiPromise = null;
+      });
+    }
   });
   return mapsApiPromise;
 }


### PR DESCRIPTION
## Details
- On `customer-app`'s search page, there's a weird bug that causes the exact same Google Maps JS SDK imported and loaded for more than one time.

## Related tickets
 - Ticket: https://homeday.atlassian.net/browse/VIEW-734
 - Sentry: https://sentry.io/organizations/homeday-de/issues/3186419210/
 - GitHub Issue: #958 

## Main changes
- 🐛 Check is the Google Maps JS SDK script already imported or not