### PR TITLE
🐛 Fix Google Maps API existence check condition

### DIFF
--- a/src/services/googleAPI.js
+++ b/src/services/googleAPI.js
@@ -9,7 +9,7 @@ export function getGoogleAPI(key) {
 
   mapsApiPromise = new Promise((resolve) => {
     // Check Google Maps version documentation: https://developers.google.com/maps/documentation/javascript/versions
-    const version = '3.42';
+    const version = 'quarterly';
     const url = `https://maps.googleapis.com/maps/api/js?v=${version}&key=${key}&libraries=places&region=DE`;
     if (window?.google) {
       resolve();

--- a/src/services/googleAPI.js
+++ b/src/services/googleAPI.js
@@ -11,7 +11,7 @@ export function getGoogleAPI(key) {
     // Check Google Maps version documentation: https://developers.google.com/maps/documentation/javascript/versions
     const version = '3.42';
     const url = `https://maps.googleapis.com/maps/api/js?v=${version}&key=${key}&libraries=places&region=DE`;
-    if (document.querySelector(`script[src="${url}"]`)) {
+    if (window?.google) {
       resolve();
     } else {
       loadScript({ url }).then(() => {


### PR DESCRIPTION
## Details
In this PR the Google Maps API existence check condition was fixed because it is not accurate as you can see in the related bug ticket.

## Related tickets
[VIEW-821](https://homeday.atlassian.net/browse/VIEW-821)

## Main changes
- Fix Google Maps API existence check condition
- Use [GMaps API quarterly release channel ](https://developers.google.com/maps/documentation/javascript/versions)because **v3.42** is retired ( since the channel is updated once per quarter it is the most predictable)
