### PR TITLE
✏️ Fix typo in DS-60 font-size

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @alieslamifard @aym3nb @DerProfi @drapisarda @ivandata @leandroinacio @limhenry @majakomel @petterHD @REX-Alexander @SusCasasola @volcanioo @hesambayat
+* @alieslamifard @AleLeonowicz @aym3nb @DerProfi @drapisarda @ivandata @leandroinacio @limhenry @majakomel @petterHD @REX-Alexander @SusCasasola @vicmion @volcanioo @hesambayat

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -8,7 +8,7 @@
 
 @mixin font($style) {
   @if ($style == "DS-60") {
-    font-size: rem-calc(12);
+    font-size: rem-calc(8);
     line-height: 1.5;
   }
   @else if ($style == "DS-80") {


### PR DESCRIPTION
## Details
This PR is about fixing a typo in the **DS-60** font-size because it should be **8** instead of **12** pixels as specified in the [DS documentation](https://ds.homeday.dev/058baf035/p/453cf2-typography/b/55e546).
![Screen Shot 2022-07-12 at 14 20 17](https://user-images.githubusercontent.com/7534298/178488216-920f9283-dc47-4205-9879-49a658541c98.png)


## Main changes
- [✏️ Fix typo in DS-60 font-size](https://github.com/homeday-de/homeday-blocks/commit/0a362d4bbc5c500ebebccb171ff4e71083c48b37)

## Additional changes
- [🎉 Add Victor & Ola to CODEOWNERS](https://github.com/homeday-de/homeday-blocks/pull/993/commits/a08ec09841bd2604dac93b0924c1ccf2225ef71e)
