### PR TITLE
📝 Add workflow status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://github.com/homeday-de/homeday-blocks/workflows/deploy-storybook/badge.svg)](https://github.com/homeday-de/homeday-blocks/actions)
+[![Release and publish](https://github.com/homeday-de/homeday-blocks/actions/workflows/release.yml/badge.svg)](https://github.com/homeday-de/homeday-blocks/actions/workflows/release.yml)
+[![Storybook deployment](https://github.com/homeday-de/homeday-blocks/actions/workflows/deploy-storybook.yml/badge.svg)](https://github.com/homeday-de/homeday-blocks/actions/workflows/deploy-storybook.yml)
 [![Coverage Status](https://coveralls.io/repos/github/homeday-de/homeday-blocks/badge.svg?t=Kbz7Vb)](https://coveralls.io/github/homeday-de/homeday-blocks)
 [![This project is using Percy.io for visual regression testing.](https://percy.io/static/images/percy-badge.svg)](https://percy.io/Homeday/homeday-blocks)
 


### PR DESCRIPTION
## Details
In this PR I added workflow status badges for [the release and publish](https://github.com/homeday-de/homeday-blocks/blob/master/.github/workflows/release.yml) and [the storybook deployment](https://github.com/homeday-de/homeday-blocks/blob/master/.github/workflows/deploy-storybook.yml) workflows, so we can easily spot when they are failing.
![Screen Shot 2022-07-13 at 10 28 28](https://user-images.githubusercontent.com/7534298/178687735-dea30f75-fe4a-4c5e-b11b-fab22c493be0.png)

## Main changes
- [📝 Add workflow status badges](https://github.com/homeday-de/homeday-blocks/commit/a96b9529319fec57863a479a6301c1d327771070)