### PR TITLE
✨ Add video support to HdGallery

### DIFF
--- a/src/components/gallery/HdGallery.vue
+++ b/src/components/gallery/HdGallery.vue
@@ -68,6 +68,7 @@
       :aspect-ratio="aspectRatio"
       :disable-key-events="disableKeyEvents"
       :object-fit="carouselObjectFit"
+      :mobile-counter-badge="mobileCounterBadge"
       class="gallery__carousel"
       @itemClick="onCarouselItemClick"
     />
@@ -90,12 +91,17 @@ export default {
     HdGalleryPlaceholder,
     HdIcon,
   },
+  inheritAttrs: false,
   props: {
     items: {
       type: Array,
       default: () => [],
     },
     pagerInside: {
+      type: Boolean,
+      default: false,
+    },
+    mobileCounterBadge: {
       type: Boolean,
       default: false,
     },

--- a/src/components/gallery/HdGalleryCarousel.vue
+++ b/src/components/gallery/HdGalleryCarousel.vue
@@ -41,6 +41,13 @@
               loading="lazy"
             >
           </picture>
+
+          <iframe
+            v-if="item.video && shouldShowActiveState(i) && isMobileView()"
+            :src="item.video"
+            class="gallery-carousel__video"
+            frameborder="0"
+          />
         </div>
       </flickity>
       <div class="gallery-carousel__pager">
@@ -51,6 +58,7 @@
           v-model="currentIndex"
         />
       </div>
+      <div v-if="mobileCounterBadge" class="gallery-carousel__info">{{ `${value + 1}/${items.length}` }}</div>
     </div>
   </div>
 </template>
@@ -77,6 +85,10 @@ export default {
       default: () => [],
     },
     pagerInside: {
+      type: Boolean,
+      default: false,
+    },
+    mobileCounterBadge: {
       type: Boolean,
       default: false,
     },
@@ -222,6 +234,11 @@ export default {
 
       this.$refs.flickity.select(targetSlide);
     },
+    isMobileView() {
+      const slidesCount = this.$refs.flickity.slides().length;
+      const cellsCount = this.$refs.flickity.cells().length;
+      return slidesCount === cellsCount;
+    },
   },
 };
 </script>
@@ -262,6 +279,23 @@ export default {
     }
   }
 
+  &__info {
+    position: absolute;
+    right: $sp-xs;
+    top: $sp-xs;
+    padding-right: $sp-s;
+    padding-left: $sp-s;
+    background-color: rgba(0, 0, 0, 0.8);
+    @include font('text-xsmall');
+    font-weight: 600;
+    color: $white;
+    border-radius: 2px;
+
+    @media (min-width: $break-tablet) {
+      display: none;
+    }
+  }
+
   &__item {
     position: relative;
     width: 100%;
@@ -296,7 +330,7 @@ export default {
     }
   }
 
-  &__picture {
+  &__picture, &__video {
     position: absolute;
     top: 0;
     right: 0;
@@ -311,6 +345,11 @@ export default {
       width: 100%;
       height: 100%;
     }
+  }
+
+  &__video {
+    width: 100%;
+    height: 100%;
   }
 }
 </style>

--- a/src/components/gallery/HdGalleryMedia.vue
+++ b/src/components/gallery/HdGalleryMedia.vue
@@ -105,6 +105,11 @@ export default {
       z-index: 1;
     }
 
+    &-picture,
+    &-video {
+      z-index: 2;
+    }
+
     &-video {
       width: 100%;
       height: 100%;

--- a/src/components/gallery/HdGalleryMedia.vue
+++ b/src/components/gallery/HdGalleryMedia.vue
@@ -5,7 +5,7 @@
 
       <!-- the item.image field is used as default value for the item image -->
       <!-- IE11 uses this value only because do not support the picture element -->
-      <picture class="gallery-media__object-picture">
+      <picture v-if="!item.video" class="gallery-media__object-picture">
         <source
           v-for="(source, media) in item.pictureSources"
           :key="media"
@@ -22,12 +22,15 @@
         />
       </picture>
 
+      <iframe v-else class="gallery-media__object-video" :src="item.video" frameborder="0" @load="hideThumbnail" />
+
       <div
         v-if="hasThumbnail"
         class="gallery-media__object-thumbnail"
         :class="{ 'isVisible': showThumbnail }"
         :style="{ 'background-image': `url('${item.thumbnail}')` }"
       />
+
     </div>
   </div>
 </template>
@@ -92,13 +95,19 @@ export default {
     cursor: pointer;
 
     &-thumbnail,
-    &-picture {
+    &-picture,
+    &-video {
       position: absolute;
       top: 0;
       right: 0;
       bottom: 0;
       left: 0;
       z-index: 1;
+    }
+
+    &-video {
+      width: 100%;
+      height: 100%;
     }
 
     &-picture {

--- a/src/stories/HdGallery.stories.js
+++ b/src/stories/HdGallery.stories.js
@@ -45,6 +45,7 @@ export default {
     disableKeyEvents: false,
     showCaption: true,
     startIndex: 0,
+    mobileCounterBadge: false,
   },
   parameters: { percy: { widths: [375] } },
 };
@@ -55,18 +56,7 @@ const Template = (args, { argTypes }) => ({
   template: `
     <div style="max-width: 800px; padding-left: 16px; padding-right: 16px; margin: auto;">
     <HdGallery
-      :items="items"
-      :pager-inside="pagerInside"
-      :aspect-ratio="aspectRatio"
-      :disable-key-events="disableKeyEvents"
-      :start-index="startIndex"
-      :show-caption="showCaption"
-      :placeholder-icon="placeholderIcon"
-      :placeholder-text="placeholderText"
-      :carousel-object-fit="carouselObjectFit"
-      @carouselItemClick="carouselItemClick"
-      @currentItemClick="currentItemClick"
-      @input="input"
+      v-bind="$props"
     />
     </div>
   `,
@@ -95,4 +85,9 @@ export const WithPagerInside = Template.bind({});
 WithPagerInside.args = {
   pagerInside: true,
   showCaption: false,
+};
+
+export const WithMobileCounterBadge = Template.bind({});
+WithMobileCounterBadge.args = {
+  mobileCounterBadge: true,
 };

--- a/src/stories/mocks/GALLERY_ITEMS.js
+++ b/src/stories/mocks/GALLERY_ITEMS.js
@@ -22,6 +22,7 @@ export default [
   {
     caption: 'Image 3',
     image: 'https://dummyimage.com/1536x364?text=3',
+    video: 'https://www.youtube-nocookie.com/embed/QwyOS8DSkYc?rel=0&start=18&end=51',
     thumbnail: 'https://dummyimage.com/154x86?text=3+thumb',
   },
   {

--- a/src/stories/mocks/GALLERY_ITEMS.js
+++ b/src/stories/mocks/GALLERY_ITEMS.js
@@ -20,8 +20,8 @@ export default [
     thumbnailSrcSet: 'https://dummyimage.com/308x172?text=2+thumb+DPR2x 2x, https://dummyimage.com/462x258?text=2+thumb+DPR3x 3x',
   },
   {
-    caption: 'Image 3',
-    image: 'https://dummyimage.com/1536x364?text=3',
+    caption: 'Video 3',
+    image: 'https://dummyimage.com/1536x364?text=Video+3',
     video: 'https://www.youtube-nocookie.com/embed/QwyOS8DSkYc?rel=0&start=18&end=51',
     thumbnail: 'https://dummyimage.com/154x86?text=3+thumb',
   },

--- a/src/stories/mocks/GALLERY_ITEMS.js
+++ b/src/stories/mocks/GALLERY_ITEMS.js
@@ -23,7 +23,7 @@ export default [
     caption: 'Video 3',
     image: 'https://dummyimage.com/1536x364?text=Video+3',
     video: 'https://www.youtube-nocookie.com/embed/QwyOS8DSkYc?rel=0&start=18&end=51',
-    thumbnail: 'https://dummyimage.com/154x86?text=3+thumb',
+    thumbnail: 'https://dummyimage.com/154x86?text=video+3+thumb',
   },
   {
     caption: 'Image 4',

--- a/tests/unit/components/__snapshots__/HdLazyImage.spec.js.snap
+++ b/tests/unit/components/__snapshots__/HdLazyImage.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HdLazyImage renders component 1`] = `<img class="lazy-image" src="https://dummyimage.com/154x86?text=3+thumb">`;
+exports[`HdLazyImage renders component 1`] = `<img class="lazy-image" src="https://dummyimage.com/154x86?text=video+3+thumb">`;

--- a/tests/unit/components/gallery/HDGallery.spec.js
+++ b/tests/unit/components/gallery/HDGallery.spec.js
@@ -19,7 +19,10 @@ describe('HdGallery', () => {
       nextButton: () => wrapper.find('.gallery__controls-next'),
       previousButton: () => wrapper.find('.gallery__controls-prev'),
       selectedPicture: () => wrapper.find('.gallery-media__object-picture'),
-      selectedPictureImg: () => wrapper.find('.gallery-media__object-picture').find('img'),
+      selectedPictureImg: () => wrapper.find('.gallery-media__object-picture').exists()
+        && wrapper.find('.gallery-media__object-picture').find('img'),
+      selectedVideo: () => wrapper.find('.gallery-media__object').exists()
+        && wrapper.find('.gallery-media__object').find('iframe'),
       selectedPictureInfo: () => wrapper.find('.gallery__info'),
       carousel: () => wrapper.findAll('.gallery__carousel'),
       carouselWrap: () => wrapper.findAll('.gallery-carousel__wrap'),
@@ -41,14 +44,20 @@ describe('HdGallery', () => {
       nextButton,
       previousButton,
       selectedPictureImg,
+      selectedVideo,
       carouselWrap,
       selectedPictureInfo,
     } = build({ items });
 
     function assetPictureIsSelected(index) {
       expect(caption().text()).toContain(items[index].caption);
-      expect(selectedPictureImg().attributes().src).toEqual(items[index].image);
-      expect(selectedPictureImg().attributes().alt).toEqual(items[index].caption);
+      if (selectedPictureImg()) {
+        expect(selectedPictureImg().attributes().src).toEqual(items[index].image);
+        expect(selectedPictureImg().attributes().alt).toEqual(items[index].caption);
+      } else {
+        expect(selectedVideo().attributes().src).toEqual(items[index].video);
+      }
+
       expect(selectedPictureInfo().text()).toContain(`${index + 1}/${items.length}`);
     }
 
@@ -104,7 +113,7 @@ describe('HdGallery', () => {
 
   it('starts the gallery at specific index', () => {
     const items = ITEMS;
-    const expectedIndex = 2;
+    const expectedIndex = 3;
     const { selectedPictureImg } = build({ items, startIndex: expectedIndex });
 
     expect(selectedPictureImg().attributes().src).toEqual(items[expectedIndex].image);

--- a/tests/unit/components/gallery/__snapshots__/HDGallery.spec.js.snap
+++ b/tests/unit/components/gallery/__snapshots__/HDGallery.spec.js.snap
@@ -45,7 +45,7 @@ exports[`HdGallery renders the component 1`] = `
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
               <div style="padding-top: 56.25%;"></div>
-              <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=3+thumb" alt="Image 3" loading="lazy" style="object-fit: cover;"></picture>
+              <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=video+3+thumb" alt="Video 3" loading="lazy" style="object-fit: cover;"></picture>
               <!---->
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">

--- a/tests/unit/components/gallery/__snapshots__/HDGallery.spec.js.snap
+++ b/tests/unit/components/gallery/__snapshots__/HDGallery.spec.js.snap
@@ -36,42 +36,52 @@ exports[`HdGallery renders the component 1`] = `
               <picture class="gallery-carousel__picture">
                 <source media="(max-width: 900px)" srcset="https://dummyimage.com/768x432?text=1+thumb+mw+900px"> <img src="https://dummyimage.com/154x86?text=1+thumb" alt="Image 1" loading="lazy" style="object-fit: cover;">
               </picture>
+              <!---->
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
               <div style="padding-top: 56.25%;"></div>
               <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=2+thumb" alt="Image 2" srcset="https://dummyimage.com/308x172?text=2+thumb+DPR2x 2x, https://dummyimage.com/462x258?text=2+thumb+DPR3x 3x" loading="lazy" style="object-fit: cover;"></picture>
+              <!---->
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
               <div style="padding-top: 56.25%;"></div>
               <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=3+thumb" alt="Image 3" loading="lazy" style="object-fit: cover;"></picture>
+              <!---->
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
               <div style="padding-top: 56.25%;"></div>
               <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=4+thumb" alt="Image 4" loading="lazy" style="object-fit: cover;"></picture>
+              <!---->
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
               <div style="padding-top: 56.25%;"></div>
               <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=5+thumb" alt="Image 5" loading="lazy" style="object-fit: cover;"></picture>
+              <!---->
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
               <div style="padding-top: 56.25%;"></div>
               <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=6+thumb" alt="Image 6" loading="lazy" style="object-fit: cover;"></picture>
+              <!---->
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
               <div style="padding-top: 56.25%;"></div>
               <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=7+thumb" alt="Image 7" loading="lazy" style="object-fit: cover;"></picture>
+              <!---->
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
               <div style="padding-top: 56.25%;"></div>
               <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=8+thumb" alt="Image 8" loading="lazy" style="object-fit: cover;"></picture>
+              <!---->
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
               <div style="padding-top: 56.25%;"></div>
               <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=9+thumb" alt="Image 9" loading="lazy" style="object-fit: cover;"></picture>
+              <!---->
             </div>
             <div class="gallery-carousel__item is-selected" style="position: absolute;">
               <div style="padding-top: 56.25%;"></div>
               <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=10+thumb" alt="Image 10" loading="lazy" style="object-fit: cover;"></picture>
+              <!---->
             </div>
           </div>
         </div>
@@ -79,6 +89,7 @@ exports[`HdGallery renders the component 1`] = `
       <div class="gallery-carousel__pager">
         <!---->
       </div>
+      <!---->
     </div>
   </div>
 </div>

--- a/tests/unit/components/gallery/__snapshots__/HdGalleryCarousel.spec.js.snap
+++ b/tests/unit/components/gallery/__snapshots__/HdGalleryCarousel.spec.js.snap
@@ -11,42 +11,52 @@ exports[`HdGalleryCarousel should render as expected 1`] = `
             <picture class="gallery-carousel__picture">
               <source media="(max-width: 900px)" srcset="https://dummyimage.com/768x432?text=1+thumb+mw+900px"> <img src="https://dummyimage.com/154x86?text=1+thumb" alt="Image 1" loading="lazy" style="object-fit: cover;">
             </picture>
+            <!---->
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
             <div style="padding-top: 56.25%;"></div>
             <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=2+thumb" alt="Image 2" srcset="https://dummyimage.com/308x172?text=2+thumb+DPR2x 2x, https://dummyimage.com/462x258?text=2+thumb+DPR3x 3x" loading="lazy" style="object-fit: cover;"></picture>
+            <!---->
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
             <div style="padding-top: 56.25%;"></div>
             <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=3+thumb" alt="Image 3" loading="lazy" style="object-fit: cover;"></picture>
+            <!---->
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
             <div style="padding-top: 56.25%;"></div>
             <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=4+thumb" alt="Image 4" loading="lazy" style="object-fit: cover;"></picture>
+            <!---->
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
             <div style="padding-top: 56.25%;"></div>
             <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=5+thumb" alt="Image 5" loading="lazy" style="object-fit: cover;"></picture>
+            <!---->
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
             <div style="padding-top: 56.25%;"></div>
             <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=6+thumb" alt="Image 6" loading="lazy" style="object-fit: cover;"></picture>
+            <!---->
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
             <div style="padding-top: 56.25%;"></div>
             <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=7+thumb" alt="Image 7" loading="lazy" style="object-fit: cover;"></picture>
+            <!---->
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
             <div style="padding-top: 56.25%;"></div>
             <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=8+thumb" alt="Image 8" loading="lazy" style="object-fit: cover;"></picture>
+            <!---->
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
             <div style="padding-top: 56.25%;"></div>
             <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=9+thumb" alt="Image 9" loading="lazy" style="object-fit: cover;"></picture>
+            <!---->
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
             <div style="padding-top: 56.25%;"></div>
             <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=10+thumb" alt="Image 10" loading="lazy" style="object-fit: cover;"></picture>
+            <!---->
           </div>
         </div>
       </div>
@@ -54,6 +64,7 @@ exports[`HdGalleryCarousel should render as expected 1`] = `
     <div class="gallery-carousel__pager">
       <!---->
     </div>
+    <!---->
   </div>
 </div>
 `;

--- a/tests/unit/components/gallery/__snapshots__/HdGalleryCarousel.spec.js.snap
+++ b/tests/unit/components/gallery/__snapshots__/HdGalleryCarousel.spec.js.snap
@@ -20,7 +20,7 @@ exports[`HdGalleryCarousel should render as expected 1`] = `
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">
             <div style="padding-top: 56.25%;"></div>
-            <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=3+thumb" alt="Image 3" loading="lazy" style="object-fit: cover;"></picture>
+            <picture class="gallery-carousel__picture"> <img src="https://dummyimage.com/154x86?text=video+3+thumb" alt="Video 3" loading="lazy" style="object-fit: cover;"></picture>
             <!---->
           </div>
           <div class="gallery-carousel__item is-selected" style="position: absolute;">

--- a/tests/unit/components/gallery/__snapshots__/HdGalleryTiles.spec.js.snap
+++ b/tests/unit/components/gallery/__snapshots__/HdGalleryTiles.spec.js.snap
@@ -10,7 +10,7 @@ exports[`HdGalleryTiles renders component 1`] = `
       <div class="lazy-image gallery-tile__image" style="background-image: url(https://dummyimage.com/154x86?text=2+thumb);"></div>
     </div>
     <div tabindex="0" class="gallery-tile">
-      <div class="lazy-image gallery-tile__image" style="background-image: url(https://dummyimage.com/154x86?text=3+thumb);"></div>
+      <div class="lazy-image gallery-tile__image" style="background-image: url(https://dummyimage.com/154x86?text=video+3+thumb);"></div>
     </div>
     <div tabindex="0" class="gallery-tile">
       <div class="lazy-image gallery-tile__image" style="background-image: url(https://dummyimage.com/154x86?text=4+thumb);"></div>


### PR DESCRIPTION
### Why?
[CA-3824](https://homeday.atlassian.net/browse/CA-3824)
According to this task, we need to add video support to the HdGallery component.

### What has been changed:
- An iframe will be added to the HdGalleryMedia, if a video is provided.
- A new prop is also added to the HdGallery called `mobileCounterBadge` to show a counter in mobile view.

### Mobile View:
![chrome-capture-2022-6-13 (2)](https://user-images.githubusercontent.com/11498216/178755798-25784b2b-731d-48de-86b7-30dcc481d076.gif)

### Desktop View
![chrome-capture-2022-6-13 (1) (1)](https://user-images.githubusercontent.com/11498216/178755881-4414351c-5dc3-4d25-aad1-6cc311082b00.gif)

