### PR TITLE
🐛 [VIEW-927] Fix hd-gallery current index NaN

### DIFF
--- a/src/components/gallery/HdGallery.vue
+++ b/src/components/gallery/HdGallery.vue
@@ -301,6 +301,7 @@ export default {
     font-weight: 600;
     color: $white;
     border-radius: 2px;
+    z-index: 2;
   }
 
   &__carousel {

--- a/src/components/gallery/HdGalleryCarousel.vue
+++ b/src/components/gallery/HdGalleryCarousel.vue
@@ -173,7 +173,7 @@ export default {
 
       // If we are showing one item per slide, we update the index on slide change
       if (slides.length === cells.length) {
-        this.$emit('input', itemIndex);
+        this.$emit('input', itemIndex || 0);
       }
     },
     onStaticClick(event, pointer, cellElement, cellIndex) {


### PR DESCRIPTION
## Details

When resizing the page, the `currentItemIndex` somehow reset to `NaN`. This causes the carousel previous/next button not working after resize, as well as `gallery__info` showing “NaN/10”

https://user-images.githubusercontent.com/4544770/179506595-f2a74769-b597-402f-8123-2a7c001a767a.mp4

## Solution

Making sure when updating the current index value, it’s not returning `undefined`. This can be fixed by changing `itemIndex` to `itemIndex || 0` so it will always return a valid number.

## Related Ticket
[VIEW-927](https://homeday.atlassian.net/browse/VIEW-927)

## Main Changes
 - 🐛 Added fallback value (`0`) when updating `currentIndex` value to prevent `undefined`