### PR TITLE
🔧 Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @alieslamifard @AleLeonowicz @aym3nb @DerProfi @drapisarda @ivandata @leandroinacio @limhenry @majakomel @petterHD @REX-Alexander @SusCasasola @vicmion @volcanioo @hesambayat
+* @alieslamifard @aym3nb @DerProfi @drapisarda @ivandata @leandroinacio @limhenry @logycode @petterHD @REX-Alexander @SusCasasola @volcanioo


### PR DESCRIPTION
In this PR, I removed the people who left 😿 and added the new teammate [Tim](https://github.com/logycode) 🎉.