### PR TITLE
✨  Add reference to hd details table

### DIFF
--- a/src/components/details-table/HdDetailsTable.vue
+++ b/src/components/details-table/HdDetailsTable.vue
@@ -26,7 +26,8 @@ export default {
     },
     reference: {
       type: String,
-      default: '',
+      required: false,
+      default: undefined,
     },
   },
 };

--- a/src/components/details-table/HdDetailsTable.vue
+++ b/src/components/details-table/HdDetailsTable.vue
@@ -24,6 +24,10 @@ export default {
       type: Boolean,
       default: true,
     },
+    reference: {
+      type: String,
+      default: '',
+    },
   },
 };
 </script>

--- a/src/stories/HdDetailsTable.stories.js
+++ b/src/stories/HdDetailsTable.stories.js
@@ -1,47 +1,52 @@
-/* eslint-disable import/no-extraneous-dependencies */
-import { storiesOf } from '@storybook/vue';
-import { boolean } from '@storybook/addon-knobs';
 import HdDetailsTable from 'homeday-blocks/src/components/details-table/HdDetailsTable.vue';
 import HdDetailsTableRow from 'homeday-blocks/src/components/details-table/HdDetailsTableRow.vue';
 
-storiesOf('Components/HdDetailsTable', module)
-  .add('default 🎛', () => ({
-    components: {
-      HdDetailsTable,
-      HdDetailsTableRow,
+export default {
+  title: 'Components/HdDetailsTable',
+  component: HdDetailsTable,
+  argTypes: {
+    withDivider: {
+      control: 'boolean',
+      description: 'Shows a divider underneath the table.',
     },
-    props: {
-      withDivider: {
-        type: Boolean,
-        default: boolean('With Divider', true),
-      },
-      forceSingleColumn: {
-        type: Boolean,
-        default: boolean('Single Column', false),
-      },
+    reference: {
+      control: 'string',
+      description: 'Used as a selector for parent components when using an attribute is not possible',
     },
-    template: `
-      <div style="max-width: 800px; margin: auto;">
-        <HdDetailsTable :with-divider="withDivider">
-          <HdDetailsTableRow
-            :force-single-column="forceSingleColumn"
-            label="First Name"
-          >
-            Chuck
-          </HdDetailsTableRow>
-          <HdDetailsTableRow
-            :force-single-column="forceSingleColumn"
-            label="Last Name"
-          >
-            Norris
-          </HdDetailsTableRow>
-          <HdDetailsTableRow
-            :force-single-column="forceSingleColumn"
-            label="Age"
-          >
-            79
-          </HdDetailsTableRow>
-        </HdDetailsTable>
-      </div>
-    `,
-  }));
+  },
+  args: {
+    withDivider: false,
+    reference: 'test',
+  },
+};
+
+const Template = (args, { argTypes }) => ({
+  components: {
+    HdDetailsTable,
+    HdDetailsTableRow,
+  },
+  props: Object.keys(argTypes),
+  template: `
+    <div style="max-width: 800px; margin: auto;">
+    <HdDetailsTable :with-divider="withDivider">
+      <HdDetailsTableRow
+        label="First Name"
+      >
+        Chuck
+      </HdDetailsTableRow>
+      <HdDetailsTableRow
+        label="Last Name"
+      >
+        Norris
+      </HdDetailsTableRow>
+      <HdDetailsTableRow
+        label="Age"
+      >
+        79
+      </HdDetailsTableRow>
+    </HdDetailsTable>
+    </div>
+  `,
+});
+
+export const Default = Template.bind({});


### PR DESCRIPTION
Adds support for a reference to target separate instances of Hd Details Table. A requirement for: [#REAL-4538](https://homeday.atlassian.net/jira/software/c/projects/REAL/boards/7?modal=detail&selectedIssue=REAL-4538) to work.