### PR TITLE
✨ [VIEW-1078] Allow user to click on the carousel item to navigate to other page using "router-link"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34444,6 +34444,12 @@
         }
       }
     },
+    "vue-router": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.5.4.tgz",
+      "integrity": "sha512-x+/DLAJZv2mcQ7glH2oV9ze8uPwcI+H+GgTgTmb5I55bCgY3+vXWIsqbYUzbBSZnwFHEJku4eoaH/x98veyymQ==",
+      "dev": true
+    },
     "vue-style-loader": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "svg-url-loader": "^7.1.1",
     "typescript": "~4.1.5",
     "vue-code-highlight": "^0.7.8",
+    "vue-router": "^3.5.4",
     "vue-template-compiler": "2.6.14"
   },
   "bugs": {

--- a/src/components/gallery/HdGallery.vue
+++ b/src/components/gallery/HdGallery.vue
@@ -20,6 +20,7 @@
           <HdGalleryMedia
             :item="currentItem"
             :aspect-ratio="aspectRatio"
+            :to="to"
           />
         </div>
         <div
@@ -69,6 +70,7 @@
       :disable-key-events="disableKeyEvents"
       :object-fit="carouselObjectFit"
       :mobile-counter-badge="mobileCounterBadge"
+      :to="to"
       class="gallery__carousel"
       @itemClick="onCarouselItemClick"
     />
@@ -133,6 +135,10 @@ export default {
       type: String,
       default: 'cover',
       validator: (value) => ['cover', 'contain', 'fill', 'scale-down', 'none'].includes(value),
+    },
+    to: {
+      type: Object,
+      default: undefined,
     },
   },
   data() {

--- a/src/components/gallery/HdGallery.vue
+++ b/src/components/gallery/HdGallery.vue
@@ -139,6 +139,11 @@ export default {
     to: {
       type: Object,
       default: undefined,
+      validator(value) {
+        // object with path or named route
+        // https://router.vuejs.org/guide/essentials/navigation.html
+        return value.path || value.name;
+      },
     },
   },
   data() {

--- a/src/components/gallery/HdGalleryCarousel.vue
+++ b/src/components/gallery/HdGalleryCarousel.vue
@@ -14,7 +14,9 @@
         ref="flickity"
         :options="flickityOptions"
       >
-        <div
+        <component
+          :is="component"
+          :to="to"
           class="gallery-carousel__item"
           v-for="(item, i) in items"
           :key="i"
@@ -48,7 +50,7 @@
             class="gallery-carousel__video"
             frameborder="0"
           />
-        </div>
+        </component>
       </flickity>
       <div class="gallery-carousel__pager">
         <HdPager
@@ -104,6 +106,10 @@ export default {
       type: String,
       default: 'cover',
     },
+    to: {
+      type: Object,
+      default: undefined,
+    },
   },
   data() {
     return {
@@ -120,6 +126,9 @@ export default {
     };
   },
   computed: {
+    component() {
+      return this.to ? 'router-link' : 'div';
+    },
     sizerStyles() {
       return {
         paddingTop: `${100 / this.aspectRatio}%`,

--- a/src/components/gallery/HdGalleryMedia.vue
+++ b/src/components/gallery/HdGalleryMedia.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="gallery-media">
+  <component :is="component" :to="to" class="gallery-media">
     <div class="gallery-media__object">
       <div :style="sizerStyles" />
 
@@ -32,7 +32,7 @@
       />
 
     </div>
-  </div>
+  </component>
 </template>
 
 <script>
@@ -47,6 +47,10 @@ export default {
       type: Number,
       default: 16 / 9,
     },
+    to: {
+      type: Object,
+      default: undefined,
+    },
   },
   data() {
     return {
@@ -54,6 +58,9 @@ export default {
     };
   },
   computed: {
+    component() {
+      return this.to ? 'router-link' : 'div';
+    },
     hasThumbnail() {
       return typeof this.item.thumbnail === 'string' && this.item.thumbnail;
     },

--- a/src/stories/HdGallery.stories.js
+++ b/src/stories/HdGallery.stories.js
@@ -1,6 +1,11 @@
+import Vue from 'vue';
+/* eslint-disable import/no-extraneous-dependencies */
+import VueRouter from 'vue-router';
 import HdGallery from 'homeday-blocks/src/components/gallery/HdGallery.vue';
 import { pictures as picturesIcon } from 'homeday-assets/L';
 import ITEMS from './mocks/GALLERY_ITEMS';
+
+Vue.use(VueRouter);
 
 export default {
   title: 'Components/Gallery/HdGallery',
@@ -38,6 +43,9 @@ export default {
     input: {
       action: 'input',
     },
+    to: {
+      action: 'to',
+    },
   },
   args: {
     items: ITEMS,
@@ -46,6 +54,7 @@ export default {
     showCaption: true,
     startIndex: 0,
     mobileCounterBadge: false,
+    to: undefined,
   },
   parameters: { percy: { widths: [375] } },
 };
@@ -60,6 +69,7 @@ const Template = (args, { argTypes }) => ({
     />
     </div>
   `,
+  router: new VueRouter({ mode: 'history' }),
 });
 
 export const Default = Template.bind({});
@@ -67,11 +77,28 @@ Default.args = {
   carouselObjectFit: 'cover',
 };
 
+export const DefaultWithLink = Template.bind({});
+DefaultWithLink.args = {
+  to: {
+    path: '/expose/YP1O2APN',
+  },
+};
+
 export const OnePhoto = Template.bind({});
 OnePhoto.args = {
   items: [
     ITEMS[0],
   ],
+};
+
+export const OnePhotoWithLink = Template.bind({});
+OnePhotoWithLink.args = {
+  items: [
+    ITEMS[0],
+  ],
+  to: {
+    path: '/expose/YP1O2APN',
+  },
 };
 
 export const NoPhotos = Template.bind({});


### PR DESCRIPTION
## Details
TL;DR: Allow user to click on the carousel item to navigate to other page using `router-link`.

The previous method was using Flickity's `staticClick`. However, this method won't work if the user want to open the link in new tab (by holding the Cmd/Ctrl button), or right click then select "Open Link in New Tab".

This can be done by using `router-link`. If there's no link, then the carousel item will fallback to `div`.

https://user-images.githubusercontent.com/4544770/183681412-7096a95d-e1b9-4295-a177-15fba46a8eb1.mov

## Related Ticket
[VIEW-1078](https://homeday.atlassian.net/browse/VIEW-1078)

## Related PR
https://github.com/homeday-de/customer-app/pull/2917

## Preview
- myHD: https://frontend-pulls.homeday.de/customer-app/2917
- Storybook: https://frontend-pulls.homeday.de/homeday-blocks/1011/

## Major Changes
- ✨`HdHallery`: Added `to` prop
- ✨`HdGalleryCarousel`, `HdGalleryMedia`: Added `to` prop and dynamic component (`div` and `router-link`)