### PR TITLE
✨ Add after slot support in HdDetailsTable

### DIFF
--- a/src/components/details-table/HdDetailsTable.vue
+++ b/src/components/details-table/HdDetailsTable.vue
@@ -12,6 +12,12 @@
       <div class="details-table__rows">
         <slot/>
       </div>
+      <div
+        v-if="$slots.after"
+        class="details-table__after"
+      >
+        <slot name="after"/>
+      </div>
     </dl>
   </div>
 </template>
@@ -69,6 +75,13 @@ export default {
       display: flex;
       flex-flow: row wrap;
       align-items: flex-start;
+    }
+  }
+
+  &__after {
+
+    @media (min-width: $break-desktop) {
+      margin-top: $sp-s;
     }
   }
 }

--- a/src/stories/HdDetailsTable.stories.js
+++ b/src/stories/HdDetailsTable.stories.js
@@ -1,3 +1,4 @@
+import HdButton from 'homeday-blocks/src/components/buttons/HdButton.vue';
 import HdDetailsTable from 'homeday-blocks/src/components/details-table/HdDetailsTable.vue';
 import HdDetailsTableRow from 'homeday-blocks/src/components/details-table/HdDetailsTableRow.vue';
 
@@ -22,6 +23,7 @@ export default {
 
 const Template = (args, { argTypes }) => ({
   components: {
+    HdButton,
     HdDetailsTable,
     HdDetailsTableRow,
   },
@@ -29,6 +31,8 @@ const Template = (args, { argTypes }) => ({
   template: `
     <div style="max-width: 800px; margin: auto;">
     <HdDetailsTable :with-divider="withDivider">
+      <template #before><h3>American martial artist</h3></template>
+
       <HdDetailsTableRow
         label="First Name"
       >
@@ -44,6 +48,8 @@ const Template = (args, { argTypes }) => ({
       >
         79
       </HdDetailsTableRow>
+
+      <template #after><HdButton>Follow</HdButton></template>
     </HdDetailsTable>
     </div>
   `,


### PR DESCRIPTION
## Details
In myHD we need to be able to add a CTA after a details table, e.g.:
![Screen Shot 2022-09-02 at 10 04 26](https://user-images.githubusercontent.com/7534298/188097791-6e3c409a-3475-47ec-880f-06887845d18b.png)
## Main changes
- Add after slot support in HdDetailsTable
- Add before/after slots in HdDetailsTable story