### PR TITLE
:wrench: Add pre-release configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - master
+      - beta
 
 jobs:
   release-and-publish:
@@ -26,7 +27,7 @@ jobs:
 
       - name: Install dependencies ⚙️
         run: npm ci
-      
+
       - name: Compile TypeScript
         run: npm run build:tsc
 

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -14,6 +14,7 @@ const commitTemplate = readFileSync(
 ).toString();
 
 module.exports = {
+  branches: ['master', { name: 'beta', prerelease: true }],
   plugins: [
     [
       'semantic-release-gitmoji', {


### PR DESCRIPTION
In order to test new features, we better have a pre-release setup. It can be achieved by publishing Beta/Alpha/RC versions. Since the beta versions can do the job, I set up the configuration to support beta versions only.

Read more: https://github.com/semantic-release/semantic-release/blob/7b7728c33c65ba801cd3bc6162cef4871b4ea0f5/docs/usage/configuration.md#branches
