### PR TITLE
🐛 [VIEW-1151] Add return to HdGoogleAutocomplete getLocation function

### DIFF
--- a/src/components/form/HdGoogleAutocomplete.vue
+++ b/src/components/form/HdGoogleAutocomplete.vue
@@ -202,6 +202,7 @@ export default {
               lng: null,
               name: this.value,
             });
+            return;
           }
 
           this.lastLocation = {


### PR DESCRIPTION
### What steps will reproduce the problem?

Sentry: https://sentry.io/organizations/homeday-de/issues/3529944572/

1. Go to myHD expose search page
2. Type “00000” (or any invalid zip code), then click on the search button
3. Visually there’s no error, but if you look at the console, then you will see this error message:
> TypeError: Cannot read properties of null (reading '0')

### What is the expected result?
`getLocation` should return object that looks like this:
```
{
    lat: null,
    lng: null,
    name: this.value,
}
```

### What happens instead of that?
The `getLocation` is returning 2 objects if the Geocoder status is NOT OK due to missing `return` in the function.

---

### Related Ticket 
[VIEW-1151](https://homeday.atlassian.net/browse/VIEW-1151)

### Main Changes
- 🐛 Add `return` to HdGoogleAutocomplete getLocation function