### PR TITLE
:bug: Fixed TS issues and added type checking tool to the build process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
           cache: npm
       - name: Install dependencies ⬇️
         run: npm ci
+      - name: Check Types 🆗
+        run: npm run type-check
       - name: Run lint 👀
         run: npm run lint:ci
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33494,9 +33494,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1289,6 +1289,30 @@
         "minimist": "^1.2.0"
       }
     },
+    "@emmetio/abbreviation": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.2.3.tgz",
+      "integrity": "sha512-87pltuCPt99aL+y9xS6GPZ+Wmmyhll2WXH73gG/xpGcQ84DRnptBsI2r0BeIQ0EB/SQTOe2ANPqFqj3Rj5FOGA==",
+      "dev": true,
+      "requires": {
+        "@emmetio/scanner": "^1.0.0"
+      }
+    },
+    "@emmetio/css-abbreviation": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.4.tgz",
+      "integrity": "sha512-qk9L60Y+uRtM5CPbB0y+QNl/1XKE09mSO+AhhSauIfr2YOx/ta3NJw2d8RtCFxgzHeRqFRr8jgyzThbu+MZ4Uw==",
+      "dev": true,
+      "requires": {
+        "@emmetio/scanner": "^1.0.0"
+      }
+    },
+    "@emmetio/scanner": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.0.tgz",
+      "integrity": "sha512-8HqW8EVqjnCmWXVpqAOZf+EGESdkR27odcMMMGefgKXtar00SoYNSryGv//TELI4T3QFsECo78p+0lmalk/CFA==",
+      "dev": true
+    },
     "@emotion/cache": {
       "version": "10.0.29",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
@@ -6839,6 +6863,65 @@
         "eslint-visitor-keys": "^2.0.0"
       }
     },
+    "@volar/code-gen": {
+      "version": "0.26.16",
+      "resolved": "https://registry.npmjs.org/@volar/code-gen/-/code-gen-0.26.16.tgz",
+      "integrity": "sha512-lMNaqPv2PnnrFy88T4GWptTkswLHlxe+floYv3z8hUAYsls74GEPj3sbI8JSQxCTji2mjW6NhrDbtjWXH/ku/g==",
+      "dev": true,
+      "requires": {
+        "@volar/shared": "^0.26.16",
+        "@volar/source-map": "^0.26.16"
+      }
+    },
+    "@volar/html2pug": {
+      "version": "0.26.16",
+      "resolved": "https://registry.npmjs.org/@volar/html2pug/-/html2pug-0.26.16.tgz",
+      "integrity": "sha512-MkbQW2a0qffyyKICvH4jqsKAMdLXwKoratW3sqoi5lK14eggksB25Dd+a2cSLdLP+EkTzhZJjAtFqtrK8Yiu7w==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0",
+        "htmlparser2": "^6.1.0",
+        "pug": "^3.0.2"
+      }
+    },
+    "@volar/shared": {
+      "version": "0.26.16",
+      "resolved": "https://registry.npmjs.org/@volar/shared/-/shared-0.26.16.tgz",
+      "integrity": "sha512-VIxOvD0DejWshFUYD6shkjQibpRFllnvmHD/i/uMbNGFIHrHdK/VThl+/g8o3fgiHowgWFyJ/Xw0Dj7r5JTtyA==",
+      "dev": true,
+      "requires": {
+        "upath": "^2.0.1",
+        "vscode-jsonrpc": "^8.0.0-next.1",
+        "vscode-uri": "^3.0.2"
+      },
+      "dependencies": {
+        "upath": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
+          "integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
+          "dev": true
+        }
+      }
+    },
+    "@volar/source-map": {
+      "version": "0.26.16",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-0.26.16.tgz",
+      "integrity": "sha512-4326LoSuND0BIM2tNTSoJJFFJv72tcwjULgBRpQzm2Oh7Mm3SC+3SIuWy3ph+MdAyGUWHjROTl8cY3abwV7NEg==",
+      "dev": true,
+      "requires": {
+        "@volar/shared": "^0.26.16"
+      }
+    },
+    "@volar/transforms": {
+      "version": "0.26.16",
+      "resolved": "https://registry.npmjs.org/@volar/transforms/-/transforms-0.26.16.tgz",
+      "integrity": "sha512-/q1clatfZmpEfFxYTGQ0cAi8ZNnBcSk7pud9OHk75WvcRoSoKX2R5gJB5ri+WztIxV/jnjXR6ktvSfbtE4YjUw==",
+      "dev": true,
+      "requires": {
+        "@volar/shared": "^0.26.16"
+      }
+    },
     "@vue/babel-helper-vue-jsx-merge-props": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-1.2.1.tgz",
@@ -8729,6 +8812,68 @@
       "resolved": "https://registry.npmjs.org/@vue/preload-webpack-plugin/-/preload-webpack-plugin-1.1.2.tgz",
       "integrity": "sha512-LIZMuJk38pk9U9Ur4YzHjlIyMuxPlACdBIHH9/nGYVTsaGKOSnSuELiE8vS9wa+dJpIYspYUOqk+L1Q4pgHQHQ==",
       "dev": true
+    },
+    "@vue/reactivity": {
+      "version": "3.2.39",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.39.tgz",
+      "integrity": "sha512-vlaYX2a3qMhIZfrw3Mtfd+BuU+TZmvDrPMa+6lpfzS9k/LnGxkSuf0fhkP0rMGfiOHPtyKoU9OJJJFGm92beVQ==",
+      "dev": true,
+      "requires": {
+        "@vue/shared": "3.2.39"
+      },
+      "dependencies": {
+        "@vue/shared": {
+          "version": "3.2.39",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.39.tgz",
+          "integrity": "sha512-D3dl2ZB9qE6mTuWPk9RlhDeP1dgNRUKC3NJxji74A4yL8M2MwlhLKUC/49WHjrNzSPug58fWx/yFbaTzGAQSBw==",
+          "dev": true
+        }
+      }
+    },
+    "@vue/reactivity-transform": {
+      "version": "3.2.39",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.39.tgz",
+      "integrity": "sha512-HGuWu864zStiWs9wBC6JYOP1E00UjMdDWIG5W+FpUx28hV3uz9ODOKVNm/vdOy/Pvzg8+OcANxAVC85WFBbl3A==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.16.4",
+        "@vue/compiler-core": "3.2.39",
+        "@vue/shared": "3.2.39",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.25.7"
+      },
+      "dependencies": {
+        "@babel/parser": {
+          "version": "7.19.1",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.1.tgz",
+          "integrity": "sha512-h7RCSorm1DdTVGJf3P2Mhj3kdnkmF/EiysUkzS2TdgAYqyjFdMQJbVuXOBej2SBJaXan/lIVtT6KkGbyyq753A==",
+          "dev": true
+        },
+        "@vue/compiler-core": {
+          "version": "3.2.39",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.39.tgz",
+          "integrity": "sha512-mf/36OWXqWn0wsC40nwRRGheR/qoID+lZXbIuLnr4/AngM0ov8Xvv8GHunC0rKRIkh60bTqydlqTeBo49rlbqw==",
+          "dev": true,
+          "requires": {
+            "@babel/parser": "^7.16.4",
+            "@vue/shared": "3.2.39",
+            "estree-walker": "^2.0.2",
+            "source-map": "^0.6.1"
+          }
+        },
+        "@vue/shared": {
+          "version": "3.2.39",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.39.tgz",
+          "integrity": "sha512-D3dl2ZB9qE6mTuWPk9RlhDeP1dgNRUKC3NJxji74A4yL8M2MwlhLKUC/49WHjrNzSPug58fWx/yFbaTzGAQSBw==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
     },
     "@vue/shared": {
       "version": "3.1.5",
@@ -14713,6 +14858,16 @@
           "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
           "dev": true
         }
+      }
+    },
+    "emmet": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.3.6.tgz",
+      "integrity": "sha512-pLS4PBPDdxuUAmw7Me7+TcHbykTsBKN/S9XJbUOMFQrNv9MoshzyMFK/R57JBm94/6HSL4vHnDeEmxlC82NQ4A==",
+      "dev": true,
+      "requires": {
+        "@emmetio/abbreviation": "^2.2.3",
+        "@emmetio/css-abbreviation": "^2.1.4"
       }
     },
     "emoji-regex": {
@@ -23249,6 +23404,12 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonc-parser": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+      "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
+      "dev": true
+    },
     "jsonfile": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
@@ -27588,6 +27749,12 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -30057,6 +30224,12 @@
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
       }
+    },
+    "request-light": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
+      "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
+      "dev": true
     },
     "request-promise": {
       "version": "4.2.6",
@@ -34278,6 +34451,283 @@
       "integrity": "sha1-YU9/v42AHwu18GYfWy9XhXUOTwk=",
       "dev": true
     },
+    "vscode-css-languageservice": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-5.4.2.tgz",
+      "integrity": "sha512-DT7+7vfdT2HDNjDoXWtYJ0lVDdeDEdbMNdK4PKqUl2MS8g7PWt7J5G9B6k9lYox8nOfhCEjLnoNC3UKHHCR1lg==",
+      "dev": true,
+      "requires": {
+        "vscode-languageserver-textdocument": "^1.0.4",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.3"
+      }
+    },
+    "vscode-emmet-helper": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/vscode-emmet-helper/-/vscode-emmet-helper-2.6.4.tgz",
+      "integrity": "sha512-fP0nunW1RUWEKGf4gqiYLOVNFFGXSRHjCl0pikxtwCFlty8WwimM+RBJ5o0aIiwerrYD30HqeaVyvDW027Sseg==",
+      "dev": true,
+      "requires": {
+        "emmet": "^2.3.0",
+        "jsonc-parser": "^2.3.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.15.1",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^2.1.2"
+      },
+      "dependencies": {
+        "vscode-uri": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.2.tgz",
+          "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==",
+          "dev": true
+        }
+      }
+    },
+    "vscode-html-languageservice": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-4.2.5.tgz",
+      "integrity": "sha512-dbr10KHabB9EaK8lI0XZW7SqOsTfrNyT3Nuj0GoPi4LjGKUmMiLtsqzfedIzRTzqY+w0FiLdh0/kQrnQ0tLxrw==",
+      "dev": true,
+      "requires": {
+        "vscode-languageserver-textdocument": "^1.0.4",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.3"
+      }
+    },
+    "vscode-json-languageservice": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.2.1.tgz",
+      "integrity": "sha512-xGmv9QIWs2H8obGbWg+sIPI/3/pFgj/5OWBhNzs00BkYQ9UaB2F6JJaGB/2/YOZJ3BvLXQTC4Q7muqU25QgAhA==",
+      "dev": true,
+      "requires": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.3",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.3"
+      },
+      "dependencies": {
+        "jsonc-parser": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+          "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+          "dev": true
+        }
+      }
+    },
+    "vscode-jsonrpc": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
+      "integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==",
+      "dev": true
+    },
+    "vscode-languageserver": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.2.tgz",
+      "integrity": "sha512-bpEt2ggPxKzsAOZlXmCJ50bV7VrxwCS5BI4+egUmure/oI/t4OlFzi/YNtVvY24A2UDOZAgwFGgnZPwqSJubkA==",
+      "dev": true,
+      "requires": {
+        "vscode-languageserver-protocol": "3.17.2"
+      }
+    },
+    "vscode-languageserver-protocol": {
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
+      "integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
+      "dev": true,
+      "requires": {
+        "vscode-jsonrpc": "8.0.2",
+        "vscode-languageserver-types": "3.17.2"
+      }
+    },
+    "vscode-languageserver-textdocument": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.7.tgz",
+      "integrity": "sha512-bFJH7UQxlXT8kKeyiyu41r22jCZXG8kuuVVA33OEJn1diWOZK5n8zBSPZFHVBOu8kXZ6h0LIRhf5UnCo61J4Hg==",
+      "dev": true
+    },
+    "vscode-languageserver-types": {
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
+      "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==",
+      "dev": true
+    },
+    "vscode-nls": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+      "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
+      "dev": true
+    },
+    "vscode-pug-languageservice": {
+      "version": "0.26.16",
+      "resolved": "https://registry.npmjs.org/vscode-pug-languageservice/-/vscode-pug-languageservice-0.26.16.tgz",
+      "integrity": "sha512-D0u+lPTg+uSsM+I/YSgOk6mCCrUOH/nD5VDWqnSIFJrtyWkPJXMZoDuKv6kZOgGMKdH/jS+MuK9XrV9uXSlHUg==",
+      "dev": true,
+      "requires": {
+        "@volar/code-gen": "^0.26.16",
+        "@volar/shared": "^0.26.16",
+        "@volar/source-map": "^0.26.16",
+        "@volar/transforms": "^0.26.16",
+        "pug-lexer": "^5.0.1",
+        "pug-parser": "^6.0.0",
+        "vscode-languageserver": "^8.0.0-next.1"
+      }
+    },
+    "vscode-typescript-languageservice": {
+      "version": "0.26.16",
+      "resolved": "https://registry.npmjs.org/vscode-typescript-languageservice/-/vscode-typescript-languageservice-0.26.16.tgz",
+      "integrity": "sha512-HvQ844GC2ZwvrcbtXdZLbx8nJwa9P4AGJ3Hu3Wk0Fb88nezuFNR4MzESoUgT9XkDCJsS9nWdoOhY3GF6KTc1cA==",
+      "dev": true,
+      "requires": {
+        "@volar/shared": "^0.26.16",
+        "upath": "^2.0.1",
+        "vscode-languageserver": "^8.0.0-next.1",
+        "vscode-languageserver-textdocument": "^1.0.1"
+      },
+      "dependencies": {
+        "upath": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
+          "integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
+          "dev": true
+        }
+      }
+    },
+    "vscode-uri": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.3.tgz",
+      "integrity": "sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA==",
+      "dev": true
+    },
+    "vscode-vue-languageservice": {
+      "version": "0.26.16",
+      "resolved": "https://registry.npmjs.org/vscode-vue-languageservice/-/vscode-vue-languageservice-0.26.16.tgz",
+      "integrity": "sha512-WElmLKx8JMg2+SjVkAC9E9i0HkI2KCcaCn2rS3D8BS5/37fCc5QWIIIUtlU22UDiEtP5qjWTyfBQE8I/9x+zaA==",
+      "dev": true,
+      "requires": {
+        "@volar/code-gen": "^0.26.16",
+        "@volar/html2pug": "^0.26.16",
+        "@volar/shared": "^0.26.16",
+        "@volar/source-map": "^0.26.16",
+        "@volar/transforms": "^0.26.16",
+        "@vue/compiler-dom": "^3.2.1",
+        "@vue/compiler-sfc": "^3.2.1",
+        "@vue/reactivity": "^3.2.1",
+        "@vue/shared": "^3.2.1",
+        "request-light": "^0.5.4",
+        "upath": "^2.0.1",
+        "vscode-css-languageservice": "^5.1.4",
+        "vscode-emmet-helper": "^2.6.4",
+        "vscode-html-languageservice": "^4.0.7",
+        "vscode-json-languageservice": "^4.1.5",
+        "vscode-languageserver": "^8.0.0-next.1",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-pug-languageservice": "^0.26.16",
+        "vscode-typescript-languageservice": "^0.26.16"
+      },
+      "dependencies": {
+        "@babel/parser": {
+          "version": "7.19.1",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.1.tgz",
+          "integrity": "sha512-h7RCSorm1DdTVGJf3P2Mhj3kdnkmF/EiysUkzS2TdgAYqyjFdMQJbVuXOBej2SBJaXan/lIVtT6KkGbyyq753A==",
+          "dev": true
+        },
+        "@vue/compiler-core": {
+          "version": "3.2.39",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.39.tgz",
+          "integrity": "sha512-mf/36OWXqWn0wsC40nwRRGheR/qoID+lZXbIuLnr4/AngM0ov8Xvv8GHunC0rKRIkh60bTqydlqTeBo49rlbqw==",
+          "dev": true,
+          "requires": {
+            "@babel/parser": "^7.16.4",
+            "@vue/shared": "3.2.39",
+            "estree-walker": "^2.0.2",
+            "source-map": "^0.6.1"
+          }
+        },
+        "@vue/compiler-dom": {
+          "version": "3.2.39",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.39.tgz",
+          "integrity": "sha512-HMFI25Be1C8vLEEv1hgEO1dWwG9QQ8LTTPmCkblVJY/O3OvWx6r1+zsox5mKPMGvqYEZa6l8j+xgOfUspgo7hw==",
+          "dev": true,
+          "requires": {
+            "@vue/compiler-core": "3.2.39",
+            "@vue/shared": "3.2.39"
+          }
+        },
+        "@vue/compiler-sfc": {
+          "version": "3.2.39",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.39.tgz",
+          "integrity": "sha512-fqAQgFs1/BxTUZkd0Vakn3teKUt//J3c420BgnYgEOoVdTwYpBTSXCMJ88GOBCylmUBbtquGPli9tVs7LzsWIA==",
+          "dev": true,
+          "requires": {
+            "@babel/parser": "^7.16.4",
+            "@vue/compiler-core": "3.2.39",
+            "@vue/compiler-dom": "3.2.39",
+            "@vue/compiler-ssr": "3.2.39",
+            "@vue/reactivity-transform": "3.2.39",
+            "@vue/shared": "3.2.39",
+            "estree-walker": "^2.0.2",
+            "magic-string": "^0.25.7",
+            "postcss": "^8.1.10",
+            "source-map": "^0.6.1"
+          }
+        },
+        "@vue/compiler-ssr": {
+          "version": "3.2.39",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.39.tgz",
+          "integrity": "sha512-EoGCJ6lincKOZGW+0Ky4WOKsSmqL7hp1ZYgen8M7u/mlvvEQUaO9tKKOy7K43M9U2aA3tPv0TuYYQFrEbK2eFQ==",
+          "dev": true,
+          "requires": {
+            "@vue/compiler-dom": "3.2.39",
+            "@vue/shared": "3.2.39"
+          }
+        },
+        "@vue/shared": {
+          "version": "3.2.39",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.39.tgz",
+          "integrity": "sha512-D3dl2ZB9qE6mTuWPk9RlhDeP1dgNRUKC3NJxji74A4yL8M2MwlhLKUC/49WHjrNzSPug58fWx/yFbaTzGAQSBw==",
+          "dev": true
+        },
+        "nanoid": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+          "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+          "dev": true
+        },
+        "postcss": {
+          "version": "8.4.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
+          "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+          "dev": true,
+          "requires": {
+            "nanoid": "^3.3.4",
+            "picocolors": "^1.0.0",
+            "source-map-js": "^1.0.2"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-js": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+          "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+          "dev": true
+        },
+        "upath": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
+          "integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
+          "dev": true
+        }
+      }
+    },
     "vue": {
       "version": "2.6.14",
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
@@ -34541,6 +34991,15 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
+    },
+    "vue-tsc": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-0.2.2.tgz",
+      "integrity": "sha512-91mzfGneWCuF83WTGRI9HA67IBUh5lrhujnFaHKWHQlpQFcBadkmz0BVoGAuJLQILetC5/CrY3is6FGiWFuY4w==",
+      "dev": true,
+      "requires": {
+        "vscode-vue-languageservice": "^0.26.6"
+      }
     },
     "vue-zoomer": {
       "version": "git+https://git@github.com/homeday-de/vue-zoomer.git#9deaceb43aa2615199f45be426ba9348edac8503",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-development",
   "description": "A Vue component library built by Homeday's frontend team.",
   "scripts": {
+    "type-check": "vue-tsc --noEmit",
     "lint": "vue-cli-service lint",
     "lint:ci": "vue-cli-service lint --no-fix",
     "build:tsc": "tsc -p tsconfig-build.json",
@@ -99,7 +100,8 @@
     "typescript": "4.5.5",
     "vue-code-highlight": "^0.7.8",
     "vue-router": "^3.5.4",
-    "vue-template-compiler": "2.6.14"
+    "vue-template-compiler": "2.6.14",
+    "vue-tsc": "0.2.2"
   },
   "bugs": {
     "url": "https://github.com/homeday-de/homeday-blocks/issues"

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "semantic-release": "^19.0.2",
     "semantic-release-gitmoji": "^1.4.4",
     "svg-url-loader": "^7.1.1",
-    "typescript": "4.8.3",
+    "typescript": "4.5.5",
     "vue-code-highlight": "^0.7.8",
     "vue-router": "^3.5.4",
     "vue-template-compiler": "2.6.14"

--- a/src/components/form/HdCheckboxCard.vue
+++ b/src/components/form/HdCheckboxCard.vue
@@ -51,7 +51,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropOptions, PropType } from 'vue';
+import Vue, { PropOptions, PropType, VueConstructor } from 'vue';
 import _isBoolean from 'lodash/fp/isBoolean';
 import deepmerge from 'deepmerge';
 import { getMessages, Language, Messages } from 'homeday-blocks/src/lang';
@@ -61,7 +61,16 @@ import HdCheckboxIndicator from './HdCheckboxIndicator.vue';
 
 export const name = 'HdCheckboxCard';
 
-export default Vue.extend({
+type VueInstance = VueConstructor<
+  Vue & {
+    $refs: {
+      checkbox: HTMLElement;
+      label: HTMLElement;
+    };
+  }
+>;
+
+export default (Vue as VueInstance).extend({
   name,
   mixins: [formFieldMixin],
   components: {

--- a/src/components/form/HdCheckboxCardGroup.vue
+++ b/src/components/form/HdCheckboxCardGroup.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import Vue, { PropOptions, VNode } from 'vue';
+import Vue, { PropOptions, PropType, VNode } from 'vue';
 import deepmerge from 'deepmerge';
 import _getOr from 'lodash/fp/getOr';
 import { customRules } from '@/@types/global';
-import { getMessages, Messages } from 'homeday-blocks/src/lang';
+import { getMessages, Language, Messages } from 'homeday-blocks/src/lang';
 import { cloneVNodeElement } from 'homeday-blocks/src/services/utils';
 import { name as HdCheckboxCardName } from 'homeday-blocks/src/components/form/HdCheckboxCard.vue';
 import formFieldMixin from './formFieldMixin';
@@ -40,7 +40,7 @@ export default Vue.extend({
       default: () => ({}),
     },
     lang: {
-      type: String,
+      type: String as PropType<Language>,
       default: 'de',
     },
     customRules: {
@@ -76,14 +76,14 @@ export default Vue.extend({
   },
   computed: {
     t(): Messages {
-      return deepmerge(getMessages(this.lang), this.texts);
+      return deepmerge(getMessages(this.lang as Language), this.texts);
     },
     hasValidationErrors(): boolean {
       return Boolean(this.error);
     },
   },
   methods: {
-    inputChanged(value) {
+    inputChanged(value: string) {
       return this.$emit('input', value);
     },
     validateForm(): string | null {

--- a/src/components/form/HdRadioCard.vue
+++ b/src/components/form/HdRadioCard.vue
@@ -47,16 +47,25 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropOptions } from 'vue';
+import Vue, { PropOptions, PropType, VueConstructor } from 'vue';
 import deepmerge from 'deepmerge';
 import { customRules } from '@/@types/global';
-import { getMessages, Messages } from 'homeday-blocks/src/lang';
+import { getMessages, Language, Messages } from 'homeday-blocks/src/lang';
 import formFieldMixin from './formFieldMixin';
 import HdRadioIndicator from './HdRadioIndicator.vue';
 
+type VueInstance = VueConstructor<
+  Vue & {
+    $refs: {
+      radio: HTMLElement;
+      label: HTMLElement;
+    };
+  }
+>;
+
 export const name = 'HdRadioCard';
 
-export default Vue.extend({
+export default (Vue as VueInstance).extend({
   name,
   mixins: [formFieldMixin],
   components: {
@@ -90,7 +99,7 @@ export default Vue.extend({
       default: () => ({}),
     },
     lang: {
-      type: String,
+      type: String as PropType<Language>,
       default: 'de',
     },
     customRules: {
@@ -123,7 +132,7 @@ export default Vue.extend({
   },
   computed: {
     t(): Messages {
-      return deepmerge(getMessages(this.lang), this.texts);
+      return deepmerge(getMessages(this.lang as Language), this.texts);
     },
     isChecked(): boolean {
       return this.nativeValue === this.value;

--- a/src/components/form/HdRadioCardGroup.vue
+++ b/src/components/form/HdRadioCardGroup.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import Vue, { PropOptions, VNode } from 'vue';
+import Vue, { PropOptions, PropType, VNode } from 'vue';
 import deepmerge from 'deepmerge';
 import _getOr from 'lodash/fp/getOr';
 import { customRules } from '@/@types/global';
-import { getMessages, Messages } from 'homeday-blocks/src/lang';
+import { getMessages, Language, Messages } from 'homeday-blocks/src/lang';
 import { cloneVNodeElement } from 'homeday-blocks/src/services/utils';
 import { name as HdRadioCardName } from 'homeday-blocks/src/components/form/HdRadioCard.vue';
 import formFieldMixin from './formFieldMixin';
@@ -39,7 +39,7 @@ export default Vue.extend({
       default: () => ({}),
     },
     lang: {
-      type: String,
+      type: String as PropType<Language>,
       default: 'de',
     },
     customRules: {
@@ -72,7 +72,7 @@ export default Vue.extend({
   },
   computed: {
     t(): Messages {
-      return deepmerge(getMessages(this.lang), this.texts);
+      return deepmerge(getMessages(this.lang as Language), this.texts);
     },
     hasValidationErrors(): boolean {
       return Boolean(this.error);


### PR DESCRIPTION
## More TS improvement
### 1. Downgrade the TS version to have better errors
I upgraded our TS version from 4.1.x to 4.8.x then changed it to 4.5.x.
So, we had some issues that were not clear enough in the console, so I downgraded to have better errors. feel free to upgrade to the latest version when the problem is fixed.

From:
<img width="1636" alt="Screen Shot 1401-06-23 at 19 09 48" src="https://user-images.githubusercontent.com/11498216/190356351-939a3878-45df-4931-b1a4-b0e0f5d55217.png">

To:
<img width="837" alt="Screen Shot 1401-06-23 at 19 13 48" src="https://user-images.githubusercontent.com/11498216/190356414-7a9a3b20-05bc-4df6-bff7-12baa88b773e.png">

### 2. Added a type checking tool to the CI process
Right now, TS errors are only visible in our IDs, even the ts build process can't build .vue files so we can't receive any TS issues from vue files. Therfore we need something like "tsc --noEmit" but for checking ts errors in .vue files.
I added a package that can do the same for our Vue files and added it to our CI process.
I also tried [this package](https://github.com/vuedx/languagetools/tree/main/packages/typecheck) but doesn't work properly.

### 3. Fixed old TS issues (12 issues) that nobody has noticed, because we didn't have the type checking tool.
<img width="1130" alt="Screen Shot 1401-06-23 at 19 29 21" src="https://user-images.githubusercontent.com/11498216/190358446-85e2359e-8e26-42dc-b379-59e6322e48f0.png">

And finally, made the build process work as expected.
<img width="301" alt="Screen Shot 1401-06-23 at 21 42 15" src="https://user-images.githubusercontent.com/11498216/190358414-dd037899-3f20-4691-805b-23ebd4a13b04.png">

