### PR TITLE
:rotating_light: Fix dateformat import error

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
-const dateFormat = require('dateformat');
+import dateFormat from 'dateformat';
+
 const { readFileSync } = require('fs');
 const { join } = require('path');
 const { gitmojis } = require('gitmojis');


### PR DESCRIPTION
## Main changes
- Fix `dateformat` import error which occurred in [the last release job](https://github.com/homeday-de/homeday-blocks/actions/runs/3112556015/jobs/5046105734#step:7:13) after it was upgraded to v5.