### PR TITLE
:bug: Fix CSS minification error in consuming projects PR deployment action

### DIFF
--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -2,7 +2,7 @@
 @import './deprecated_font';
 
 @function rem-calc($size) {
-  $remSize: calc($size / 16);
+  $remSize: calc(#{$size} / 16);
   @return #{$remSize}rem;
 }
 


### PR DESCRIPTION
## Details
When trying to use the latest blocks version in [myHomeday](https://github.com/homeday-de/customer-app/pull/3038), all checks passed except the PR deployment action which failed with [the error](https://github.com/homeday-de/customer-app/actions/runs/3376982506/jobs/5605745877#step:7:112):

> Error: CSS minification error: Lexical error on line 1: Unrecognized text.
  Erroneous area:
1: $size / 16

Which is simply fixed by wrapping `#{$size}` (Check [Sass interpolation docs](https://sass-lang.com/documentation/interpolation))

## Related PRs
https://github.com/homeday-de/customer-app/pull/3038