### PR TITLE
:bug: Fix unresolved hd-tooltip directive in consuming projects

### DIFF
--- a/src/components/tooltip/HdTooltipInstaller.js
+++ b/src/components/tooltip/HdTooltipInstaller.js
@@ -1,9 +1,7 @@
-/* eslint-disable no-new */
-import Vue from 'vue';
 import tooltipDirective from './tooltipDirective';
 import HdTooltip from './HdTooltip.vue';
 
-export default function install() {
+export default function install(Vue) {
   Vue.directive('hd-tooltip', tooltipDirective);
   const TooltipComponent = Vue.extend(HdTooltip);
   new TooltipComponent().$mount();


### PR DESCRIPTION
## Main changes
- Use the consuming project's Vue instance instead blocks own instance to register the directive to ensure that it gets registered even if their Vue version doesn't match ours.