### PR TITLE
🔧 Update CODEOWNERS [skip ci]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @alieslamifard @aym3nb @DerProfi @drapisarda @ivandata @leandroinacio @limhenry @logycode @petterHD @REX-Alexander @SusCasasola @volcanioo
+* @alieslamifard @aym3nb @leandroinacio @petterHD @REX-Alexander @SusCasasola


### PR DESCRIPTION
## Main changes
- Update `CODEOWNERS` according to the latest Homeday frontend team setup.