### PR TITLE
:bug: Fix the "cannot divide by px" issue

### DIFF
--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -13,7 +13,7 @@
 @function strip-unit($number) {
   @if type-of($number) == 'number' and not unitless($number) {
     $divisor: $number * 0 + 1;
-    @return calc(#{$number} / #{$divisor});
+    @return calc(#{$number / $divisor});
   }
 
   @return $number;


### PR DESCRIPTION
Tested as suggested by @aym3nb https://github.com/homeday-de/website/pull/1531#issuecomment-1340926758
This time it works 😊

```
ERROR in ./node_modules/homeday-blocks/src/components/form/HdRange.vue?vue&type=style&index=0&id=f46fdbec&prod&lang=scss& (./node_modules/css-loader/dist/cjs.js??ref--7-oneOf-1-1!./node_modules/vue-loader/lib/loaders/stylePostLoader.js!./node_modules/postcss-loader/dist/cjs.js??ref--7-oneOf-1-2!./node_modules/sass-loader/dist/cjs.js??ref--7-oneOf-1-3!./node_modules/sass-resources-loader/lib/loader.js??ref--7-oneOf-1-4!./node_modules/@nuxt/components/dist/loader.js??ref--0-0!./node_modules/vue-loader/lib??vue-loader-options!./node_modules/homeday-blocks/src/components/form/HdRange.vue?vue&type=style&index=0&id=f46fdbec&prod&lang=scss&)
Module build failed (from ./node_modules/postcss-loader/dist/cjs.js):
Error: Cannot divide by "px", number expected
    at /Users/leandrosouza/Documents/workspace/website/node_modules/homeday-blocks/src/components/form/HdRange.vue:1:698
```
