### PR TITLE
✨ Allow raw html on the labels of the radio items

### DIFF
--- a/src/components/form/HdRadio.vue
+++ b/src/components/form/HdRadio.vue
@@ -49,9 +49,7 @@
           :disabled="disabled"
           :invalid="hasError"
         />
-        <label :for="getItemName(item)" class="radio__label">
-          {{ item.label }}
-        </label>
+        <label :for="getItemName(item)" class="radio__label" v-html="item.label" />
       </div>
     </div>
   </FieldBase>

--- a/src/stories/HdRadio.stories.js
+++ b/src/stories/HdRadio.stories.js
@@ -236,3 +236,35 @@ Unlabelled.parameters = {
     },
   },
 };
+
+export const RawHTML = Template.bind({});
+RawHTML.args = {
+  items: [
+    {
+      value: 'EXAMPLE',
+      label: 'This is a <b>Bold</b> text.',
+    },
+  ],
+};
+RawHTML.parameters = {
+  docs: {
+    description: {
+      story: `You can also send raw HTML to the label as a string, for example to have bold words.`,
+    },
+    source: {
+      code: `
+<template>
+  <HdRadio
+    v-model="myDataProperty"
+    :name="name"
+    :items="[{
+      value: 'EXAMPLE',
+      label: 'This is a <b>Bold</b> text.'
+    }]"
+    label=""
+  />
+</template>
+      `,
+    },
+  },
+};

--- a/tests/unit/components/form/HdRadio.spec.js
+++ b/tests/unit/components/form/HdRadio.spec.js
@@ -130,4 +130,19 @@ describe('HdRadio', () => {
 
     expect(wrapper.find('input').attributes().disabled).toBe('disabled');
   });
+
+  it('Supports raw html', () => {
+    const wrapper = wrapperBuilder({
+      props: {
+        items: [
+          {
+            value: 'EXAMPLE',
+            label: 'This is a <b>Bold</b> text.',
+          },
+        ],
+      },
+    });
+
+    expect(wrapper.find('b').exists()).toBe(true);
+  });
 });

--- a/tests/unit/components/form/__snapshots__/HdRadio.spec.js.snap
+++ b/tests/unit/components/form/__snapshots__/HdRadio.spec.js.snap
@@ -7,29 +7,19 @@ exports[`HdRadio is rendered as expected 1`] = `
     <div class="field__main">
       <div role="radiogroup" class="radio-wrapper">
         <div aria-checked="false" tabindex="0" class="radio"><input id="testRadio-jon" name="testRadio-jon" type="radio" value="jon">
-          <div class="radio-indicator"></div> <label for="testRadio-jon" class="radio__label">
-            Jon "Snow"
-          </label>
+          <div class="radio-indicator"></div> <label for="testRadio-jon" class="radio__label">Jon "Snow"</label>
         </div>
         <div aria-checked="false" tabindex="-1" class="radio"><input id="testRadio-daenerys" name="testRadio-daenerys" type="radio" value="daenerys">
-          <div class="radio-indicator"></div> <label for="testRadio-daenerys" class="radio__label">
-            Daenerys
-          </label>
+          <div class="radio-indicator"></div> <label for="testRadio-daenerys" class="radio__label">Daenerys</label>
         </div>
         <div aria-checked="false" tabindex="-1" class="radio"><input id="testRadio-nightKing" name="testRadio-nightKing" type="radio" value="nightKing">
-          <div class="radio-indicator"></div> <label for="testRadio-nightKing" class="radio__label">
-            The Night King
-          </label>
+          <div class="radio-indicator"></div> <label for="testRadio-nightKing" class="radio__label">The Night King</label>
         </div>
         <div aria-checked="false" tabindex="-1" class="radio"><input id="testRadio-arya" name="testRadio-arya" type="radio" value="arya">
-          <div class="radio-indicator"></div> <label for="testRadio-arya" class="radio__label">
-            Arya
-          </label>
+          <div class="radio-indicator"></div> <label for="testRadio-arya" class="radio__label">Arya</label>
         </div>
         <div aria-checked="false" tabindex="-1" class="radio"><input id="testRadio-cersei" name="testRadio-cersei" type="radio" value="cersei">
-          <div class="radio-indicator"></div> <label for="testRadio-cersei" class="radio__label">
-            Cersei
-          </label>
+          <div class="radio-indicator"></div> <label for="testRadio-cersei" class="radio__label">Cersei</label>
         </div>
       </div> <label for="testRadio" id="test-radio-label" class="field__label">
         test radio label


### PR DESCRIPTION
There are some cases when I need to render options with a bold text inside the label of a radio buttons.

That was not allowed before, so I changed the label inside the Radio Items to allow raw HTML as a prop.

![image](https://user-images.githubusercontent.com/17165301/217958196-699858b6-c32a-4ab0-9883-9a87a91d8e3f.png)
