### PR TITLE
:bug: Fix the UI for inputs of type date

### DIFF
--- a/src/components/form/FieldBase.vue
+++ b/src/components/form/FieldBase.vue
@@ -186,12 +186,16 @@ export default {
       transform: translateY(-50%) scale(0.75);
     }
 
+    [type='date'] ~ & {
+      @include minimized;
+    }
+
     #{$root}--active &,
     #{$root}--filled &,
     #{$root}--minimized-label & {
       @include minimized;
     }
-    // We are seperating this declaration from the block above
+    // We are separating this declaration from the block above
     // because non-webkit engines will ignore the whole block, e.g. Gecko
     input:-webkit-autofill + & {
       @include minimized;

--- a/src/components/form/HdInput.vue
+++ b/src/components/form/HdInput.vue
@@ -61,7 +61,7 @@ export default {
       default: 'text',
     },
     value: {
-      type: [String, Number],
+      type: [String, Number, Date],
       default: '',
     },
     placeholder: {

--- a/src/stories/HdInput.stories.js
+++ b/src/stories/HdInput.stories.js
@@ -166,4 +166,20 @@ storiesOf('Components/Form/HdInput', module)
         value: '',
       };
     },
+  }))
+  .add('with type date', () => ({
+    components: { HdInput },
+    template: `
+      <HdInput
+        v-model="value"
+        name="test"
+        label="Label"
+        type="date"
+      />
+    `,
+    data() {
+      return {
+        value: '',
+      };
+    },
   }));


### PR DESCRIPTION
**Before:**
![blocks homeday dev_iframe html_args= id=components-form-hdinput--number viewMode=story](https://github.com/homeday-de/homeday-blocks/assets/2879127/f42bb0bc-5393-4b35-bae0-e93aaae0ead4)

**After:**
![localhost_6006_iframe html_args= id=components-form-hdinput--with-type-date viewMode=story](https://github.com/homeday-de/homeday-blocks/assets/2879127/e1b4b55d-0f95-4105-829f-7b538e574d24)

Also fixed the return type option for the value - we are getting a Vue warn when we use the date field.
