### PR TITLE
:sparkles: Introduce customizable bullets for HdRange

### DIFF
--- a/src/stories/HdRange.stories.js
+++ b/src/stories/HdRange.stories.js
@@ -1,182 +1,143 @@
-/* eslint-disable import/no-extraneous-dependencies, no-console */
-import { storiesOf } from '@storybook/vue';
 import HdRange from 'homeday-blocks/src/components/form/HdRange.vue';
-import FormWrapper from 'homeday-blocks/src/storiesWrappers/FormWrapper';
-import { number, boolean, text } from '@storybook/addon-knobs';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { text } from '@storybook/addon-knobs';
 
-storiesOf('Components/Form/HdRange', module)
-  .addDecorator(FormWrapper)
-  .add('default 🎛', () => ({
-    components: { HdRange },
-    template: `
-      <div>
-        <HdRange
-          :min="min"
-          :max="max"
-          :step="step"
-          :disabled="disabled"
-          :displayStepBullets="displayStepBullets"
-          v-model="currentValue"
-        />
-        <p>Value: {{ currentValue }}</p>
-      </div>
-    `,
-    props: {
-      value: {
-        type: Number,
-        default: number('value', 50),
-      },
-      min: {
-        type: Number,
-        default: number('min', 0),
-      },
-      max: {
-        type: Number,
-        default: number('max', 100),
-      },
-      step: {
-        type: Number,
-        default: number('step', 10),
-      },
-      disabled: {
-        type: Boolean,
-        default: boolean('disabled', false),
-      },
-      displayStepBullets: {
-        type: Boolean,
-        default: boolean('displayStepBullets', false),
-      },
+export default {
+  title: 'Components/Form/HdRange',
+  component: HdRange,
+  args: {
+    name: 'storybook',
+    required: false,
+    disabled: false,
+    min: 0,
+    max: 100,
+    step: 1,
+    value: 50,
+    labels: [],
+    displayStepBullets: false,
+    displayTooltip: false,
+    tooltipValue: '',
+    trackBackground: '',
+    progressBackground: '',
+    stepBullets: [],
+  },
+};
+
+const Template = (_, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { HdRange },
+  template: `
+    <div style="margin: 64px auto; max-width: 360px;">
+      <HdRange 
+        v-bind="$props"
+        v-model="currentValue" 
+      />
+      <p style="margin-top: 50px;">Value: {{ currentValue }}</p>
+    </div>
+  `,
+  data() {
+    return {
+      currentValue: 50,
+    };
+  },
+});
+
+export const Default = Template.bind({});
+
+export const WithBullets = Template.bind({});
+WithBullets.args = {
+  displayStepBullets: true,
+  step: 20,
+};
+
+export const WithTooltip = Template.bind({});
+WithTooltip.args = {
+  displayTooltip: true,
+};
+
+export const WithLabels = (_, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { HdRange },
+  template: `
+    <div style="margin: 64px auto; max-width: 360px;">
+      <HdRange 
+        v-bind="$props"
+        v-model="currentValue" 
+      />
+      <p style="margin-top: 50px;">Value: {{ currentValue }}</p>
+    </div>
+  `,
+  data() {
+    return {
+      currentValue: 2,
+    };
+  },
+});
+WithLabels.args = {
+  min: 0,
+  max: 6,
+  displayStepBullets: true,
+  labels: ['Mon.', 'Tue.', 'Wed.', 'Thu.', 'Fri.', 'Sat.', 'Sun.'],
+};
+
+export const CustomBackgrounds = Template.bind({});
+CustomBackgrounds.args = {
+  trackBackground: text(
+    'track-background',
+    'radial-gradient(circle at center, #4CBA38, #FFE713, #E00016)'
+  ),
+  progressBackground: text('progress-background', 'transparent'),
+};
+
+export const WithCustomTooltipValue = (_, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { HdRange },
+  template: `
+    <div style="margin: 64px auto; max-width: 360px;">
+      <HdRange 
+        v-bind="$props"
+        :tooltipValue="tooltipVal"
+        v-model="currentValue" 
+      />
+      <p style="margin-top: 50px;">Value: {{ currentValue }}</p>
+    </div>
+  `,
+  data() {
+    return {
+      currentValue: 2,
+    };
+  },
+  computed: {
+    tooltipVal() {
+      return ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'][
+        this.currentValue
+      ];
     },
-    watch: {
-      value() {
-        this.currentValue = this.value;
-      },
-    },
-    data() {
-      return {
-        currentValue: this.value,
-      };
-    },
-  }))
-  .add('with bullets', () => ({
-    components: { HdRange },
-    template: `
-      <div>
-        <HdRange
-          :min="0"
-          :max="100"
-          :step="20"
-          :disabled="false"
-          displayStepBullets
-          v-model="currentValue"
-        />
-        <p>Value: {{ currentValue }}</p>
-      </div>
-    `,
-    data() {
-      return {
-        currentValue: 50,
-      };
-    },
-  }))
-  .add('with tooltip', () => ({
-    components: { HdRange },
-    template: `
-      <div>
-        <HdRange
-          :min="0"
-          :max="100"
-          :step="10"
-          displayTooltip
-          v-model="currentValue"
-        />
-        <p>Value: {{ currentValue }}</p>
-      </div>
-    `,
-    data() {
-      return {
-        currentValue: 50,
-      };
-    },
-  }))
-  .add('with custom tooltip value', () => ({
-    components: { HdRange },
-    template: `
-      <div>
-        <HdRange
-          v-model="currentValue"
-          :min="0"
-          :max="6"
-          displayTooltip
-          :tooltipValue="tooltipValue"
-        />
-        <p>Value: {{ currentValue }}</p>
-      </div>
-    `,
-    data() {
-      return {
-        currentValue: 0,
-      };
-    },
-    computed: {
-      tooltipValue() {
-        return ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'][
-          this.currentValue
-        ];
-      },
-    },
-  }))
-  .add('with labels', () => ({
-    components: { HdRange },
-    template: `
-      <div>
-        <HdRange
-          v-model="currentValue"
-          :min="0"
-          :max="6"
-          displayStepBullets
-          :labels="labels"
-        />
-        <p>Value: {{ currentValue }}</p>
-      </div>
-    `,
-    data() {
-      return {
-        currentValue: 0,
-        labels: ['Mon.', 'Tue.', 'Wed.', 'Thu.', 'Fri.', 'Sat.', 'Sun.'],
-      };
-    },
-  }))
-  .add('custom backgrounds 🎛', () => ({
-    components: { HdRange },
-    template: `
-      <div>
-        <HdRange
-          v-model="currentValue"
-          :min="0"
-          :max="4"
-          :track-background="trackBackground"
-          :progress-background="progressBackground"
-        />
-        <p>Value: {{ currentValue }}</p>
-      </div>
-    `,
-    props: {
-      trackBackground: {
-        type: String,
-        default: text(
-          'track-background',
-          'radial-gradient(circle at center, #4CBA38, #FFE713, #E00016)'
-        ),
-      },
-      progressBackground: {
-        type: String,
-        default: text('progress-background', 'transparent'),
-      },
-    },
-    data() {
-      return {
-        currentValue: 2,
-      };
-    },
-  }));
+  },
+});
+WithCustomTooltipValue.args = {
+  ...WithLabels.args,
+  displayTooltip: true,
+};
+
+export const WithCustomStepBullets = (_, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { HdRange },
+  template: `
+    <div style="margin: 64px auto; max-width: 360px;">
+      <HdRange 
+        v-bind="$props"
+        :min="1"
+        :max="100"
+        :step-bullets="[1, 26, 40, 95, 100]"
+        v-model="currentValue"
+      />
+      <p style="margin-top: 50px;">Value: {{ currentValue }}</p>
+    </div>
+  `,
+  data() {
+    return {
+      currentValue: 26,
+    };
+  },
+});

--- a/tests/unit/components/form/HdRange.spec.js
+++ b/tests/unit/components/form/HdRange.spec.js
@@ -243,4 +243,31 @@ describe('HdRange', () => {
 
     expect(mockedUpdateUI).toHaveBeenCalledTimes(2);
   });
+
+  describe('Custom step bullets', () => {
+    const VISIBLE_STEP_BULLETS_SELECTOR = '.range__step';
+    const stepBulletsWrapperBuilder = wrapperFactoryBuilder(HdRange, {
+      props: {
+        name: 'storybook',
+        min: 1,
+        max: 100,
+        step: 1,
+        value: 50,
+        labels: [],
+        displayStepBullets: false,
+        stepBullets: [1, 10, 50, 60, 100],
+      },
+    });
+
+    it('renders custom step bullets', () => {
+      const wrapper = stepBulletsWrapperBuilder();
+      expect(wrapper.findAll(VISIBLE_STEP_BULLETS_SELECTOR).length).toBe(5);
+    });
+    it('updates value to closest step bullet', async () => {
+      const wrapper = stepBulletsWrapperBuilder();
+      wrapper.setProps({ value: 90 });
+      await wrapper.vm.$nextTick();
+      expect(wrapper.emitted().input[0][0]).toBe(100);
+    });
+  });
 });


### PR DESCRIPTION
[TOFU-5447](https://homeday.atlassian.net/browse/TOFU-5447)

To be able to implement a page change in realtor app, matching the Figma layout.
Currently, bullets are always even steps (which means, they show up every 1 step).

In some cases, most of the bullets are even, but one option (the default one) differs.
![localhost_6006_iframe html_args= id=components-form-hdrange--with-custom-step-bullets viewMode=story](https://github.com/homeday-de/homeday-blocks/assets/2879127/210a2903-4334-43e7-ac94-a0949e8cfac2)

To achieve that, we offer a new prop, an array receiving the value (in number) of where the steps/bullets should be placed.
That way we can draw the step and move the bullet accordingly to the next accepted step if the user clicks in between them.

You can check the new storybook to better understand it.

I have also updated the storybook file to match the new standard, but all previous stories were kept.