### PR TITLE
🔧 Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @alieslamifard @aym3nb @leandroinacio @petterHD @REX-Alexander @SusCasasola
+* @alieslamifard @aym3nb @leandroinacio


### PR DESCRIPTION
## Main changes
- Update `CODEOWNERS` to include only the actual Homeday frontend team.